### PR TITLE
Convert Configuration Command and basic migrators

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
   ],
   "require": {
     "php": ">=5.5.0",
-    "illuminate/support": "~5.1",
-    "illuminate/database": "~5.1",
-    "illuminate/console": "~5.1",
+    "illuminate/support": "~5.0",
+    "illuminate/database": "~5.0",
+    "illuminate/console": "~5.0",
     "doctrine/orm": "2.5.*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "php": ">=5.5.0",
     "illuminate/support": "~5.1",
     "illuminate/database": "~5.1",
+    "illuminate/console": "~5.1",
     "doctrine/orm": "2.5.*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,11 @@
   ],
   "require": {
     "php": ">=5.5.0",
-    "illuminate/support": "~5.0",
-    "illuminate/database": "~5.0",
-    "illuminate/console": "~5.0",
+    "illuminate/support": "~5.1",
+    "illuminate/database": "~5.1",
+    "illuminate/console": "~5.1",
+    "illuminate/view": "~5.1",
+    "philo/laravel-blade": "3.*",
     "doctrine/orm": "2.5.*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     "illuminate/database": "~5.1",
     "illuminate/console": "~5.1",
     "illuminate/view": "~5.1",
-    "philo/laravel-blade": "3.*",
     "doctrine/orm": "2.5.*"
   },
   "require-dev": {

--- a/src/Console/ConfigMigrations/ConfigurationMigrator.php
+++ b/src/Console/ConfigMigrations/ConfigurationMigrator.php
@@ -4,5 +4,5 @@ namespace LaravelDoctrine\ORM\ConfigMigrations;
 
 interface ConfigurationMigrator
 {
-    function convertConfiguration($sourceArray);
+    public function convertConfiguration($sourceArray);
 }

--- a/src/Console/ConfigMigrations/ConfigurationMigrator.php
+++ b/src/Console/ConfigMigrations/ConfigurationMigrator.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace LaravelDoctrine\ORM\ConfigMigrations;
+
+interface ConfigurationMigrator
+{
+    function convertConfiguration($sourceArray);
+}

--- a/src/Console/ConfigMigrations/MitchellMigrator.php
+++ b/src/Console/ConfigMigrations/MitchellMigrator.php
@@ -10,10 +10,9 @@ class MitchellMigrator implements ConfigurationMigrator
 {
     private $defaultConfig;
 
-    public function __construct($defaultConfig)
+    public function __construct()
     {
-        $this->blade = new Blade('src/Console/ConfigMigrations/templates/mitchell', 'src/Console/ConfigMigrations/templates');
-        $this->defaultConfig = $defaultConfig;
+        $this->blade = new Blade(realpath(__DIR__ . '/templates/mitchell'), realpath(__DIR__ . '/templates'));
     }
 
     public function convertConfiguration($sourceArray)
@@ -25,8 +24,6 @@ class MitchellMigrator implements ConfigurationMigrator
         $cache = '';
         $dqls = null;
 
-        //$config['dev'] = config('app.debug');
-
         if ($isFoxxMD) {
             foreach ($sourceArray['entity_managers'] as $key => $manager) {
                 $managers[$key] = $this->convertManager($manager, $isFoxxMD);
@@ -35,21 +32,13 @@ class MitchellMigrator implements ConfigurationMigrator
             $managers['default'] = $this->convertManager($sourceArray, $isFoxxMD);
         }
 
-        //$config['meta']         = $this->defaultConfig['meta'];
-        //$config['extensions']   = $this->defaultConfig['extensions'];
-        //$config['custom_types'] = $this->defaultConfig['custom_types'];
-
         if ($isFoxxMD) {
             $dqls = $this->convertDQL($sourceArray['entity_managers']);
-            /*            if (!empty($dqls)) {
-                            array_push($config, $dqls);
-                        }*/
         }
 
-        //$config['debugbar'] = $this->defaultConfig['debugbar'];
         $cache    = $this->convertCache($sourceArray);
 
-        $results = $this->blade->view()->make('defaults', ['managers' => $managers, 'cache' => $cache, 'dqls' => $dqls])->render();
+        $results = $this->blade->view()->make('master', ['managers' => $managers, 'cache' => $cache, 'dqls' => $dqls])->render();
         $unescaped = html_entity_decode($results, ENT_QUOTES);
 
         return $unescaped;
@@ -60,17 +49,6 @@ class MitchellMigrator implements ConfigurationMigrator
         $results = $this->blade->view()->make('manager', ['data' => $sourceArray, 'isFork' => $isFoxxMD])->render();
         $unescaped = html_entity_decode($results, ENT_QUOTES);
         return $unescaped;
-        /*        return [
-                    'meta'       => $isFoxxMD ? $sourceArray['metadata']['driver'] : 'annotations',
-                    'connection' => $isFoxxMD ? $sourceArray['connection'] : config('database.default'),
-                    'paths'      => ArrayUtil::get($sourceArray['metadata']['paths'], $sourceArray['metadata']),
-                    'repository' => ArrayUtil::get($sourceArray['repository'], ORM\EntityRepository::class),
-                    'proxies'    => [
-                        'namespace'     => ArrayUtil::get($sourceArray['proxy']['namespace'], false),
-                        'path'          => ArrayUtil::get($sourceArray['proxy']['directory'], storage_path('proxies')),
-                        'auto_generate' => ArrayUtil::get($sourceArray['proxy']['auto_generate'], env('DOCTRINE_PROXY_AUTOGENERATE', false))
-                    ]
-                ];*/
     }
 
     public function convertCache($sourceArray)
@@ -79,10 +57,6 @@ class MitchellMigrator implements ConfigurationMigrator
         $results = $this->blade->view()->make('cache', ['cacheProvider' => $cacheProvider])->render();
         $unescaped = html_entity_decode($results, ENT_QUOTES);
         return $unescaped;
-        /*        return [
-                    'default'      => $cacheProvider == null ? config('cache.default') : config('cache.' . $cacheProvider),
-                    'second_level' => false,
-                ];*/
     }
 
     public function convertDQL($sourceManagers)

--- a/src/Console/ConfigMigrations/MitchellMigrator.php
+++ b/src/Console/ConfigMigrations/MitchellMigrator.php
@@ -3,15 +3,18 @@
 namespace LaravelDoctrine\ORM\ConfigMigrations;
 
 use Doctrine\ORM;
+use Illuminate\Contracts\View\Factory;
 use LaravelDoctrine\ORM\Utilities\ArrayUtil;
-use View;
 
 class MitchellMigrator implements ConfigurationMigrator
 {
-    public function __construct()
+    private $viewFactory;
+
+    public function __construct(Factory $viewFactory)
     {
-        View::addLocation(realpath(__DIR__ . '/templates'));
-        View::addNamespace('mitchell', realpath(__DIR__ . '/templates/mitchell'));
+        $this->viewFactory = $viewFactory;
+        //add namespace for views
+        $this->viewFactory->addNamespace('mitchell', realpath(__DIR__ . '/templates/mitchell'));
     }
 
     public function convertConfiguration($sourceArray)
@@ -37,7 +40,7 @@ class MitchellMigrator implements ConfigurationMigrator
 
         $cache    = $this->convertCache($sourceArray);
 
-        $results = View::make('mitchell.master', ['managers' => $managers, 'cache' => $cache, 'dqls' => $dqls])->render();
+        $results = $this->viewFactory->make('mitchell.master', ['managers' => $managers, 'cache' => $cache, 'dqls' => $dqls])->render();
         $unescaped = html_entity_decode($results, ENT_QUOTES);
 
         return $unescaped;
@@ -45,7 +48,7 @@ class MitchellMigrator implements ConfigurationMigrator
 
     public function convertManager($sourceArray, $isFoxxMD)
     {
-        $results = View::make('mitchell.manager', ['data' => $sourceArray, 'isFork' => $isFoxxMD])->render();
+        $results = $this->viewFactory->make('mitchell.manager', ['data' => $sourceArray, 'isFork' => $isFoxxMD])->render();
         $unescaped = html_entity_decode($results, ENT_QUOTES);
         return $unescaped;
     }
@@ -53,7 +56,7 @@ class MitchellMigrator implements ConfigurationMigrator
     public function convertCache($sourceArray)
     {
         $cacheProvider = ArrayUtil::get($sourceArray['cache_provider']);
-        $results = View::make('mitchell.cache',['cacheProvider' => $cacheProvider])->render();
+        $results = $this->viewFactory->make('mitchell.cache',['cacheProvider' => $cacheProvider])->render();
         $unescaped = html_entity_decode($results, ENT_QUOTES);
         return $unescaped;
     }
@@ -76,7 +79,7 @@ class MitchellMigrator implements ConfigurationMigrator
         }
 
         if(!empty($dqls)){
-            $results = View::make('mitchel.dql', ['dql' => $dqls])->render();
+            $results = $this->viewFactory->make('mitchel.dql', ['dql' => $dqls])->render();
             $unescaped = html_entity_decode($results, ENT_QUOTES);
             return $unescaped;
         } else {

--- a/src/Console/ConfigMigrations/MitchellMigrator.php
+++ b/src/Console/ConfigMigrations/MitchellMigrator.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: mduncan
+ * Date: 7/14/15
+ * Time: 3:38 PM
+ */
+
+namespace LaravelDoctrine\ORM\ConfigMigrations;
+
+
+use LaravelDoctrine\ORM\Utilities\ArrayUtil;
+use Doctrine\ORM;
+
+class MitchellMigrator implements ConfigurationMigrator
+{
+    private $defaultConfig;
+
+    public function __construct($defaultConfig)
+    {
+        $this->defaultConfig = $defaultConfig;
+    }
+
+    function convertConfiguration($sourceArray)
+    {
+        //determine if configuration is from FoxxMD fork or original Mitchell repo
+        $isFoxxMD = ArrayUtil::get($sourceArray['entity_managers']) !== null;
+
+        $config['dev'] = config('app.debug');
+
+        if ($isFoxxMD) {
+            foreach ($sourceArray['entity_managers'] as $manager) {
+                $config['managers'] = $this->convertManager($manager, $isFoxxMD);
+            }
+        } else {
+            $config['managers']['default'] = $this->convertManager($sourceArray, $isFoxxMD);
+        }
+
+        $config['meta'] = $this->defaultConfig['meta'];
+        $config['extensions'] = $this->defaultConfig['extensions'];
+        $config['custom_types'] = $this->defaultConfig['custom_types'];
+
+        if($isFoxxMD){
+            $dqls = $this->convertDQL($sourceArray['entity_managers']);
+            if(!empty($dqls)){
+                array_push($config, $dqls);
+            }
+        }
+
+        $config['debugbar'] = $this->defaultConfig['debugbar'];
+        $config['cache'] = $this->convertCache($sourceArray);
+
+        return $config;
+    }
+
+    function convertManager($sourceArray, $isFoxxMD)
+    {
+        return [
+            'meta' => $isFoxxMD ? $sourceArray['metadata']['driver'] : 'annotations',
+            'connection' => $isFoxxMD ? $sourceArray['connection'] : config('database.default'),
+            'paths' => ArrayUtil::get($sourceArray['metadata']['paths'], $sourceArray['metadata']),
+            'repository' => ArrayUtil::get($sourceArray['repository'], ORM\EntityRepository::class),
+            'proxies' => [
+                'namespace' => ArrayUtil::get($sourceArray['proxy']['namespace'], false),
+                'path' => ArrayUtil::get($sourceArray['proxy']['directory'], storage_path('proxies')),
+                'auto_generate' => ArrayUtil::get($sourceArray['proxy']['auto_generate'], env('DOCTRINE_PROXY_AUTOGENERATE', false))
+            ]
+        ];
+    }
+
+    function convertCache($sourceArray)
+    {
+        $cacheProvider = ArrayUtil::get($sourceArray['cache_provider']);
+        return [
+            'default' => $cacheProvider == null ? config('cache.default') : config('cache.' . $cacheProvider),
+            'second_level' => false,
+        ];
+    }
+
+    function convertDQL($sourceManagers)
+    {
+        $dqls = [];
+        foreach ($sourceManagers as $manager) {
+            if (($dql = ArrayUtil::get($manager['dql'])) !== null) {
+                if (($dt = ArrayUtil::get($manager['dql']['datetime_functions'])) !== null) {
+                    array_push($dqls['custom_datetime_functions'], $dt);
+                }
+                if (($num = ArrayUtil::get($manager['dql']['numeric_functions'])) !== null) {
+                    array_push($dqls['custom_numeric_functions'], $num);
+                }
+                if (($string = ArrayUtil::get($manager['dql']['string_functions'])) !== null) {
+                    array_push($dqls['custom_string_functions'], $string);
+                }
+            }
+        }
+        return $dqls;
+    }
+}

--- a/src/Console/ConfigMigrations/MitchellMigrator.php
+++ b/src/Console/ConfigMigrations/MitchellMigrator.php
@@ -46,9 +46,9 @@ class MitchellMigrator implements ConfigurationMigrator
         return $unescaped;
     }
 
-    public function convertManager($sourceArray, $isFoxxMD)
+    public function convertManager($sourceArray, $isFork)
     {
-        $results = $this->viewFactory->make('mitchell.manager', ['data' => $sourceArray, 'isFork' => $isFoxxMD])->render();
+        $results = $this->viewFactory->make('mitchell.manager', ['data' => $sourceArray, 'isFork' => $isFork])->render();
         $unescaped = html_entity_decode($results, ENT_QUOTES);
         return $unescaped;
     }

--- a/src/Console/ConfigMigrations/MitchellMigrator.php
+++ b/src/Console/ConfigMigrations/MitchellMigrator.php
@@ -1,16 +1,9 @@
 <?php
-/**
- * Created by IntelliJ IDEA.
- * User: mduncan
- * Date: 7/14/15
- * Time: 3:38 PM
- */
 
 namespace LaravelDoctrine\ORM\ConfigMigrations;
 
-
-use LaravelDoctrine\ORM\Utilities\ArrayUtil;
 use Doctrine\ORM;
+use LaravelDoctrine\ORM\Utilities\ArrayUtil;
 
 class MitchellMigrator implements ConfigurationMigrator
 {
@@ -21,7 +14,7 @@ class MitchellMigrator implements ConfigurationMigrator
         $this->defaultConfig = $defaultConfig;
     }
 
-    function convertConfiguration($sourceArray)
+    public function convertConfiguration($sourceArray)
     {
         //determine if configuration is from FoxxMD fork or original Mitchell repo
         $isFoxxMD = ArrayUtil::get($sourceArray['entity_managers']) !== null;
@@ -36,48 +29,49 @@ class MitchellMigrator implements ConfigurationMigrator
             $config['managers']['default'] = $this->convertManager($sourceArray, $isFoxxMD);
         }
 
-        $config['meta'] = $this->defaultConfig['meta'];
-        $config['extensions'] = $this->defaultConfig['extensions'];
+        $config['meta']         = $this->defaultConfig['meta'];
+        $config['extensions']   = $this->defaultConfig['extensions'];
         $config['custom_types'] = $this->defaultConfig['custom_types'];
 
-        if($isFoxxMD){
+        if ($isFoxxMD) {
             $dqls = $this->convertDQL($sourceArray['entity_managers']);
-            if(!empty($dqls)){
+            if (!empty($dqls)) {
                 array_push($config, $dqls);
             }
         }
 
         $config['debugbar'] = $this->defaultConfig['debugbar'];
-        $config['cache'] = $this->convertCache($sourceArray);
+        $config['cache']    = $this->convertCache($sourceArray);
 
         return $config;
     }
 
-    function convertManager($sourceArray, $isFoxxMD)
+    public function convertManager($sourceArray, $isFoxxMD)
     {
         return [
-            'meta' => $isFoxxMD ? $sourceArray['metadata']['driver'] : 'annotations',
+            'meta'       => $isFoxxMD ? $sourceArray['metadata']['driver'] : 'annotations',
             'connection' => $isFoxxMD ? $sourceArray['connection'] : config('database.default'),
-            'paths' => ArrayUtil::get($sourceArray['metadata']['paths'], $sourceArray['metadata']),
+            'paths'      => ArrayUtil::get($sourceArray['metadata']['paths'], $sourceArray['metadata']),
             'repository' => ArrayUtil::get($sourceArray['repository'], ORM\EntityRepository::class),
-            'proxies' => [
-                'namespace' => ArrayUtil::get($sourceArray['proxy']['namespace'], false),
-                'path' => ArrayUtil::get($sourceArray['proxy']['directory'], storage_path('proxies')),
+            'proxies'    => [
+                'namespace'     => ArrayUtil::get($sourceArray['proxy']['namespace'], false),
+                'path'          => ArrayUtil::get($sourceArray['proxy']['directory'], storage_path('proxies')),
                 'auto_generate' => ArrayUtil::get($sourceArray['proxy']['auto_generate'], env('DOCTRINE_PROXY_AUTOGENERATE', false))
             ]
         ];
     }
 
-    function convertCache($sourceArray)
+    public function convertCache($sourceArray)
     {
         $cacheProvider = ArrayUtil::get($sourceArray['cache_provider']);
+
         return [
-            'default' => $cacheProvider == null ? config('cache.default') : config('cache.' . $cacheProvider),
+            'default'      => $cacheProvider == null ? config('cache.default') : config('cache.' . $cacheProvider),
             'second_level' => false,
         ];
     }
 
-    function convertDQL($sourceManagers)
+    public function convertDQL($sourceManagers)
     {
         $dqls = [];
         foreach ($sourceManagers as $manager) {
@@ -93,6 +87,7 @@ class MitchellMigrator implements ConfigurationMigrator
                 }
             }
         }
+
         return $dqls;
     }
 }

--- a/src/Console/ConfigMigrations/templates/mitchell/cache.blade.php
+++ b/src/Console/ConfigMigrations/templates/mitchell/cache.blade.php
@@ -1,0 +1,4 @@
+[
+    'default' => {{{is_null($cacheProvider) ? 'config("cache.default")' : 'config("cache.'.$cacheProvider.'")'}}},
+    'second_level' => false,
+]

--- a/src/Console/ConfigMigrations/templates/mitchell/dql.blade.php
+++ b/src/Console/ConfigMigrations/templates/mitchell/dql.blade.php
@@ -1,0 +1,21 @@
+@if(\LaravelDoctrine\ORM\Utilities\ArrayUtil::get($dql['datetime_functions']) !== null)
+    'custom_datetime_functions' => [
+    @foreach($dql['datetime_functions'] as $key => $val)
+        '{{$key}}' => '{{$val}}'
+        @endforeach
+    ],
+@endif
+@if(\LaravelDoctrine\ORM\Utilities\ArrayUtil::get($dql['numeric_functions']) !== null)
+    'custom_numeric_functions' => [
+    @foreach($dql['numeric_functions'] as $key => $val)
+        '{{$key}}' => '{{$val}}'
+    @endforeach
+    ],
+@endif
+@if(\LaravelDoctrine\ORM\Utilities\ArrayUtil::get($dql['string_functions']) !== null)
+    'custom_string_functions' => [
+    @foreach($dql['string_functions'] as $key => $val)
+        '{{$key}}' => '{{$val}}'
+    @endforeach
+    ],
+@endif

--- a/src/Console/ConfigMigrations/templates/mitchell/manager.blade.php
+++ b/src/Console/ConfigMigrations/templates/mitchell/manager.blade.php
@@ -1,0 +1,16 @@
+[
+    'meta' => '{{{ $isFork ? $data['metadata']['driver'] : 'annotations' }}}',
+    'connection' => {{{ $isFork ? '\''.$data['connection'].'\'' : 'config(\"database.default\")'  }}},
+    'paths' => {{ var_export(\LaravelDoctrine\ORM\Utilities\ArrayUtil::get($data['metadata']['paths'], $data['metadata']), true) }},
+    'repository' => '{{{ \LaravelDoctrine\ORM\Utilities\ArrayUtil::get($data['repository'], \LaravelDoctrine\ORM\EntityRepository::class) }}}',
+    'proxies' => [
+        'namespace' => {{{ isset($data['proxy']['namespace']) ? '\'' . $data['proxy']['namespace'] .'\'' : 'false' }}},
+        'path'          => '{{{ \LaravelDoctrine\ORM\Utilities\ArrayUtil::get($data['proxy']['directory'], storage_path('proxies')) }}}',
+        'auto_generate' => {{{ \LaravelDoctrine\ORM\Utilities\ArrayUtil::get($data['proxy']['auto_generate'], env('DOCTRINE_PROXY_AUTOGENERATE', 'false')) }}}
+    ],
+    'events'     => [
+        'listeners'   => [],
+        'subscribers' => []
+    ],
+    'filters' => []
+]

--- a/src/Console/ConfigMigrations/templates/mitchell/manager.blade.php
+++ b/src/Console/ConfigMigrations/templates/mitchell/manager.blade.php
@@ -1,12 +1,12 @@
 [
     'meta' => '{{{ $isFork ? $data['metadata']['driver'] : 'annotations' }}}',
-    'connection' => {{{ $isFork ? '\''.$data['connection'].'\'' : 'config(\"database.default\")'  }}},
+    'connection' => {{{ $isFork ? '\''.$data['connection'].'\'' : 'config("database.default")'  }}},
     'paths' => {{ var_export(\LaravelDoctrine\ORM\Utilities\ArrayUtil::get($data['metadata']['paths'], $data['metadata']), true) }},
     'repository' => '{{{ \LaravelDoctrine\ORM\Utilities\ArrayUtil::get($data['repository'], \LaravelDoctrine\ORM\EntityRepository::class) }}}',
     'proxies' => [
         'namespace' => {{{ isset($data['proxy']['namespace']) ? '\'' . $data['proxy']['namespace'] .'\'' : 'false' }}},
         'path'          => '{{{ \LaravelDoctrine\ORM\Utilities\ArrayUtil::get($data['proxy']['directory'], storage_path('proxies')) }}}',
-        'auto_generate' => {{{ \LaravelDoctrine\ORM\Utilities\ArrayUtil::get($data['proxy']['auto_generate'], env('DOCTRINE_PROXY_AUTOGENERATE', 'false')) }}}
+        'auto_generate' => '{{{ \LaravelDoctrine\ORM\Utilities\ArrayUtil::get($data['proxy']['auto_generate'], env('DOCTRINE_PROXY_AUTOGENERATE', 'false')) }}}'
     ],
     'events'     => [
         'listeners'   => [],

--- a/src/Console/ConfigMigrations/templates/mitchell/master.blade.php
+++ b/src/Console/ConfigMigrations/templates/mitchell/master.blade.php
@@ -1,0 +1,44 @@
+return [
+        'dev'                       => config('app.debug'),
+        'managers'                  => [
+                @foreach($managers as $key => $manager)
+                    '{{$key}}' => {{$manager}},
+                    @endforeach
+
+        ],
+        'meta'                      => [
+                'namespaces' => [
+                        'App'
+                ],
+                'drivers'    => [
+                        'annotations' => [
+                                'driver' => 'annotations',
+                                'simple' => false
+                        ],
+                        'yaml'        => [
+                                'driver' => 'yaml'
+                        ],
+                        'xml'         => [
+                                'driver' => 'xml'
+                        ],
+                        'config'      => [
+                                'driver'       => 'config',
+                                'mapping_file' => 'mappings'
+                        ],
+                        'static_php'  => [
+                                'driver' => 'static_php'
+                        ]
+                ]
+        ],
+        'extensions'                => [
+            //LaravelDoctrine\ORM\Extensions\TablePrefix\TablePrefixExtension::class,
+        ],
+        'custom_types'              => [
+                'json' => LaravelDoctrine\ORM\Types\Json::class
+        ],
+        @if($dqls !== null)
+            {{$dqls}}
+            @endif
+        'debugbar'                  => env('DOCTRINE_DEBUGBAR', false),
+        {{$cache}}
+];

--- a/src/Console/ConvertConfigCommand.php
+++ b/src/Console/ConvertConfigCommand.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by IntelliJ IDEA.
- * User: mduncan
- * Date: 7/14/15
- * Time: 2:04 PM
- */
 
 namespace LaravelDoctrine\ORM\Console;
 
@@ -21,16 +15,15 @@ class ConvertConfigCommand extends Command
 
     public function fire()
     {
-
         if (($destPath = $this->option('dest-path')) === null) {
             $destPath = 'config';
         }
 
-        if(($author = $this->argument('author')) === null){
+        if (($author = $this->argument('author')) === null) {
             throw new InvalidArgumentException('Missing author option');
         }
 
-        if(($sourceFilePath = $this->option('source-file')) === null){
+        if (($sourceFilePath = $this->option('source-file')) === null) {
             $sourceFilePath = 'config/doctrine.php';
         }
 
@@ -63,8 +56,7 @@ class ConvertConfigCommand extends Command
         //TODO make this relative
         $defaultArrayConfig = include '../../config/doctrine.php';
 
-
-        switch($author){
+        switch ($author) {
             case 'atrauzzi':
                 $convertedArrayConfig = $this->convertAtrauzzi($sourceArrayConfig, $defaultArrayConfig);
                 break;
@@ -79,13 +71,15 @@ class ConvertConfigCommand extends Command
         $this->info('Conversion successful. File generated at ' . $destFilePath);
     }
 
-    private function convertMitchell($sourceConfig, $defaultconfig){
+    private function convertMitchell($sourceConfig, $defaultconfig)
+    {
         $mMigrator = new MitchellMigrator($defaultconfig);
+
         return $mMigrator->convertConfiguration($sourceConfig);
     }
 
-    private function convertAtrauzzi($sourceConfig){
-
+    private function convertAtrauzzi($sourceConfig)
+    {
     }
 
     public function getArguments()
@@ -98,9 +92,9 @@ class ConvertConfigCommand extends Command
 
     protected function getOptions()
     {
-        return array(
+        return [
             ['dest-path', null, InputOption::VALUE_OPTIONAL, 'Where the generated configuration should be placed. Default is config.', 'config'],
             ['source-file', null, InputOption::VALUE_OPTIONAL, 'Where the source configuration file is located. Default is config/doctrine.php', 'config/doctrine.php']
-        );
+        ];
     }
 }

--- a/src/Console/ConvertConfigCommand.php
+++ b/src/Console/ConvertConfigCommand.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: mduncan
+ * Date: 7/14/15
+ * Time: 2:04 PM
+ */
+
+namespace LaravelDoctrine\ORM\Console;
+
+use InvalidArgumentException;
+use LaravelDoctrine\ORM\ConfigMigrations\MitchellMigrator;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class ConvertConfigCommand extends Command
+{
+    protected $name = 'doctrine:config:convert';
+
+    protected $description = 'Convert the configuration file for another laravel-doctrine implementation into a valid configuration for LaravelDoctrine\ORM.';
+
+    public function fire()
+    {
+
+        if (($destPath = $this->option('dest-path')) === null) {
+            $destPath = 'config';
+        }
+
+        if(($author = $this->argument('author')) === null){
+            throw new InvalidArgumentException('Missing author option');
+        }
+
+        if(($sourceFilePath = $this->option('source-file')) === null){
+            $sourceFilePath = 'config/doctrine.php';
+        }
+
+        $destPath = realpath($destPath);
+
+        if (!is_dir($destPath)) {
+            mkdir($destPath, 0777, true);
+        }
+
+        if (!is_writable($destPath)) {
+            throw new InvalidArgumentException(
+                sprintf("Configuration destination directory '<info>%s</info>' does not have write permissions.",
+                    $destPath)
+            );
+        }
+
+        $destFilePath = $destPath . '/doctrine.generated.php';
+
+        $sourceFilePath = realPath($sourceFilePath);
+
+        if (!file_exists($sourceFilePath)) {
+            throw new InvalidArgumentException(
+                sprintf("Source file at path '<info>%s</info>' does not exist.",
+                    $sourceFilePath)
+            );
+        }
+
+        $sourceArrayConfig = include $sourceFilePath;
+
+        //TODO make this relative
+        $defaultArrayConfig = include '../../config/doctrine.php';
+
+
+        switch($author){
+            case 'atrauzzi':
+                $convertedArrayConfig = $this->convertAtrauzzi($sourceArrayConfig, $defaultArrayConfig);
+                break;
+            case 'mitchellvanw':
+                $convertedArrayConfig = $this->convertMitchell($sourceArrayConfig, $defaultArrayConfig);
+                break;
+            default:
+                throw new InvalidArgumentException('Author provided was not a valid choice.');
+        }
+
+        file_put_contents($destFilePath, '<?php return ' . var_export($convertedArrayConfig, true) . ';');
+        $this->info('Conversion successful. File generated at ' . $destFilePath);
+    }
+
+    private function convertMitchell($sourceConfig, $defaultconfig){
+        $mMigrator = new MitchellMigrator($defaultconfig);
+        return $mMigrator->convertConfiguration($sourceConfig);
+    }
+
+    private function convertAtrauzzi($sourceConfig){
+
+    }
+
+    public function getArguments()
+    {
+        return [
+            ['author', InputArgument::REQUIRED, 'The name of the author of the repository being migrated from. Options are "atrauzzi" and "mitchellvanw"'],
+
+        ];
+    }
+
+    protected function getOptions()
+    {
+        return array(
+            ['dest-path', null, InputOption::VALUE_OPTIONAL, 'Where the generated configuration should be placed. Default is config.', 'config'],
+            ['source-file', null, InputOption::VALUE_OPTIONAL, 'Where the source configuration file is located. Default is config/doctrine.php', 'config/doctrine.php']
+        );
+    }
+}

--- a/src/Console/ConvertConfigCommand.php
+++ b/src/Console/ConvertConfigCommand.php
@@ -2,6 +2,7 @@
 
 namespace LaravelDoctrine\ORM\Console;
 
+use Illuminate\Contracts\View\Factory;
 use InvalidArgumentException;
 use LaravelDoctrine\ORM\ConfigMigrations\MitchellMigrator;
 use Symfony\Component\Console\Input\InputArgument;
@@ -13,8 +14,11 @@ class ConvertConfigCommand extends Command
 
     protected $description = 'Convert the configuration file for another laravel-doctrine implementation into a valid configuration for LaravelDoctrine\ORM.';
 
-    public function fire()
+    public function fire(Factory $viewFactory)
     {
+        //add config templates directory to view locations
+        $viewFactory->addLocation(realpath(__DIR__ . '/ConfigMigrations/templates'));
+
         if (($destPath = $this->option('dest-path')) === null) {
             $destPath = 'config';
         }
@@ -54,12 +58,14 @@ class ConvertConfigCommand extends Command
 
         $sourceArrayConfig = include $sourceFilePath;
 
+        //TODO make this relative
+
         switch ($author) {
             case 'atrauzzi':
-                $convertedConfigString = $this->convertAtrauzzi($sourceArrayConfig, $defaultArrayConfig);
+                //$convertedConfigString = $this->convertAtrauzzi($sourceArrayConfig, $viewFactory);
                 break;
             case 'mitchellvanw':
-                $convertedConfigString = $this->convertMitchell($sourceArrayConfig, $defaultArrayConfig);
+                $convertedConfigString = $this->convertMitchell($sourceArrayConfig, $viewFactory);
                 break;
             default:
                 throw new InvalidArgumentException('Author provided was not a valid choice.');
@@ -69,15 +75,16 @@ class ConvertConfigCommand extends Command
         $this->info('Conversion successful. File generated at ' . $destFilePath);
     }
 
-    private function convertMitchell($sourceConfig)
+    private function convertMitchell($sourceConfig, $viewFactory)
     {
-        $mMigrator = new MitchellMigrator();
+        $mMigrator = new MitchellMigrator($viewFactory);
 
         return $mMigrator->convertConfiguration($sourceConfig);
     }
 
-    private function convertAtrauzzi($sourceConfig)
+    private function convertAtrauzzi($sourceConfig, $viewFactory)
     {
+        //TODO
     }
 
     public function getArguments()

--- a/src/Console/ConvertConfigCommand.php
+++ b/src/Console/ConvertConfigCommand.php
@@ -58,16 +58,16 @@ class ConvertConfigCommand extends Command
 
         switch ($author) {
             case 'atrauzzi':
-                $convertedArrayConfig = $this->convertAtrauzzi($sourceArrayConfig, $defaultArrayConfig);
+                $convertedConfigString = $this->convertAtrauzzi($sourceArrayConfig, $defaultArrayConfig);
                 break;
             case 'mitchellvanw':
-                $convertedArrayConfig = $this->convertMitchell($sourceArrayConfig, $defaultArrayConfig);
+                $convertedConfigString = $this->convertMitchell($sourceArrayConfig, $defaultArrayConfig);
                 break;
             default:
                 throw new InvalidArgumentException('Author provided was not a valid choice.');
         }
 
-        file_put_contents($destFilePath, '<?php return ' . var_export($convertedArrayConfig, true) . ';');
+        file_put_contents($destFilePath, '<?php ' . $convertedConfigString);
         $this->info('Conversion successful. File generated at ' . $destFilePath);
     }
 

--- a/src/Console/ConvertConfigCommand.php
+++ b/src/Console/ConvertConfigCommand.php
@@ -42,19 +42,17 @@ class ConvertConfigCommand extends Command
 
         $destFilePath = $destPath . '/doctrine.generated.php';
 
+        $originalSourceFilePath = $sourceFilePath;
         $sourceFilePath = realPath($sourceFilePath);
 
         if (!file_exists($sourceFilePath)) {
             throw new InvalidArgumentException(
                 sprintf("Source file at path '<info>%s</info>' does not exist.",
-                    $sourceFilePath)
+                    $originalSourceFilePath)
             );
         }
 
         $sourceArrayConfig = include $sourceFilePath;
-
-        //TODO make this relative
-        $defaultArrayConfig = include '../../config/doctrine.php';
 
         switch ($author) {
             case 'atrauzzi':
@@ -71,9 +69,9 @@ class ConvertConfigCommand extends Command
         $this->info('Conversion successful. File generated at ' . $destFilePath);
     }
 
-    private function convertMitchell($sourceConfig, $defaultconfig)
+    private function convertMitchell($sourceConfig)
     {
-        $mMigrator = new MitchellMigrator($defaultconfig);
+        $mMigrator = new MitchellMigrator();
 
         return $mMigrator->convertConfiguration($sourceConfig);
     }

--- a/src/DoctrineServiceProvider.php
+++ b/src/DoctrineServiceProvider.php
@@ -24,6 +24,7 @@ use LaravelDoctrine\ORM\Configuration\MetaData\MetaDataManager;
 use LaravelDoctrine\ORM\Console\ClearMetadataCacheCommand;
 use LaravelDoctrine\ORM\Console\ClearQueryCacheCommand;
 use LaravelDoctrine\ORM\Console\ClearResultCacheCommand;
+use LaravelDoctrine\ORM\Console\ConvertConfigCommand;
 use LaravelDoctrine\ORM\Console\EnsureProductionSettingsCommand;
 use LaravelDoctrine\ORM\Console\GenerateProxiesCommand;
 use LaravelDoctrine\ORM\Console\InfoCommand;
@@ -363,7 +364,8 @@ class DoctrineServiceProvider extends ServiceProvider
             ClearResultCacheCommand::class,
             ClearQueryCacheCommand::class,
             EnsureProductionSettingsCommand::class,
-            GenerateProxiesCommand::class
+            GenerateProxiesCommand::class,
+            ConvertConfigCommand::class
         ]);
     }
 

--- a/src/Utilities/ArrayUtil.php
+++ b/src/Utilities/ArrayUtil.php
@@ -1,17 +1,11 @@
 <?php
-/**
- * Created by IntelliJ IDEA.
- * User: mduncan
- * Date: 7/14/15
- * Time: 3:47 PM
- */
 
 namespace LaravelDoctrine\ORM\Utilities;
 
-
 class ArrayUtil
 {
-    public static function get(&$var, $default = null) {
+    public static function get(&$var, $default = null)
+    {
         return isset($var) ? $var : $default;
     }
 }

--- a/src/Utilities/ArrayUtil.php
+++ b/src/Utilities/ArrayUtil.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: mduncan
+ * Date: 7/14/15
+ * Time: 3:47 PM
+ */
+
+namespace LaravelDoctrine\ORM\Utilities;
+
+
+class ArrayUtil
+{
+    public static function get(&$var, $default = null) {
+        return isset($var) ? $var : $default;
+    }
+}


### PR DESCRIPTION
This PR implements the ConvertConfigCommand in order to allow users coming from other laravel-doctrine packages to generate a compatible configuration from their existing configuration.

Fixes #4 and addresses #5 (though not perfect yet)