### PR TITLE
Change default argument behavior for getting an EM with no arguments to manager

### DIFF
--- a/src/DoctrineServiceProvider.php
+++ b/src/DoctrineServiceProvider.php
@@ -207,11 +207,11 @@ class DoctrineServiceProvider extends ServiceProvider
             list($managers, $connections) = $this->setUpEntityManagers();
 
             return new IlluminateRegistry(
-                head($managers),
+                isset($managers['default']) ? $managers['default'] : head($managers),
                 $connections,
                 $managers,
-                head($connections),
-                head($managers),
+                isset($connections['default']) ? $connections['default'] : head($connections),
+                isset($managers['default']) ? $managers['default'] : head($managers),
                 Proxy::class,
                 $app
             );


### PR DESCRIPTION
Allows more options for getting the default EM by looking first for any connections or managers with the name 'default', then if none exists fallback to head