### PR TITLE
Do not defer provider

### DIFF
--- a/src/DoctrineServiceProvider.php
+++ b/src/DoctrineServiceProvider.php
@@ -49,7 +49,7 @@ class DoctrineServiceProvider extends ServiceProvider
      * Indicates if loading of the provider is deferred.
      * @var bool
      */
-    protected $defer = true;
+    protected $defer = false;
 
     /**
      * Boot service provider.
@@ -57,7 +57,6 @@ class DoctrineServiceProvider extends ServiceProvider
     public function boot(CustomTypeManager $typeManager)
     {
         $typeManager->addCustomTypes(config('doctrine.custom_types', []));
-        $this->extendAuthManager();
 
         // Boot the extension manager
         $this->app->make(ExtensionManager::class)->boot();
@@ -84,6 +83,7 @@ class DoctrineServiceProvider extends ServiceProvider
         $this->registerExtensions();
         $this->registerPresenceVerifier();
         $this->registerConsoleCommands();
+        $this->extendAuthManager();
     }
 
     /**

--- a/src/DoctrineServiceProvider.php
+++ b/src/DoctrineServiceProvider.php
@@ -49,7 +49,7 @@ class DoctrineServiceProvider extends ServiceProvider
      * Indicates if loading of the provider is deferred.
      * @var bool
      */
-    protected $defer = false;
+    protected $defer = true;
 
     /**
      * Boot service provider.
@@ -418,6 +418,7 @@ class DoctrineServiceProvider extends ServiceProvider
     public function provides()
     {
         return [
+            'auth',
             'em',
             'validation.presence',
             'migration.repository',


### PR DESCRIPTION
Do not defer provider during application boot and extend auth manager during registration. This fixes a bug where the auth manager cannot access entities because laraveldoctrine hasn't initialized yet.

I ran in to a problem where [AuthManager](https://github.com/illuminate/auth/blob/master/AuthManager.php#L16) attempted to create a driver for a callback to view entities and threw an exception because doctrine hadn't been initialized. 

The solution I found to fix this was to call `extendAuthManager()` in `register` and change the provider to not be deferred. This way doctrine was ready to go by the time the auth manager needs to make a call.