### PR TITLE
Add PasswordReminder::loadMetadata()

### DIFF
--- a/src/Auth/Passwords/PasswordReminder.php
+++ b/src/Auth/Passwords/PasswordReminder.php
@@ -47,4 +47,30 @@ class PasswordReminder
     {
         return $this->createdAt;
     }
+
+    /**
+     * Metadata definition for static_php metadata driver.
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $metadata
+     * @return void
+     */
+    public static function loadMetadata(\Doctrine\ORM\Mapping\ClassMetadata $metadata)
+    {
+        $metadata->setTableName('password_resets');
+
+        $metadata->mapField(array(
+            'id' => true,
+            'fieldName' => 'email',
+            'type' => 'string',
+        ));
+        $metadata->mapField(array(
+            'fieldName' => 'token',
+            'type' => 'string',
+        ));
+        $metadata->mapField(array(
+            'columnName' => 'created_at',
+            'fieldName' => 'createdAt',
+            'type' => 'datetime',
+            'nullable' => false,
+        ));
+    }
 }


### PR DESCRIPTION
The PasswordReminder entity now supports the static_php metadata driver.