### PR TITLE
Fixing incorrect function name

### DIFF
--- a/src/IlluminateRegistry.php
+++ b/src/IlluminateRegistry.php
@@ -81,7 +81,7 @@ final class IlluminateRegistry implements ManagerRegistry
      */
     public function addConnection($connection)
     {
-        if (!$this->container->bound($this->getManagerBindingName($connection))) {
+        if (!$this->container->bound($this->getConnectionBindingName($connection))) {
             $this->container->singleton($this->getConnectionBindingName($connection), function () use ($connection) {
                 return $this->getManager($connection)->getConnection();
             });


### PR DESCRIPTION
Correcting the function name used to determine if a new connection
should be created. Was checking for Manager being Bound, rather than
Connection being bound.