### PR TITLE
Added the ability to add multiple listeners to each event.

### DIFF
--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -132,13 +132,34 @@ class EntityManagerFactory
     {
         if (isset($settings['events']['listeners'])) {
             foreach ($settings['events']['listeners'] as $event => $listener) {
-                if (!class_exists($listener, false)) {
-                    throw new InvalidArgumentException("Listener {$listener} does not exist");
-                }
-
-                $manager->getEventManager()->addEventListener($event, new $listener);
+                $this->registerListener($event, $listener, $manager);
             }
         }
+    }
+
+    /**
+     * @param string                 $event
+     * @param string|string[]        $listener
+     * @param EntityManagerInterface $manager
+     */
+    private function registerListener($event, $listener, EntityManagerInterface $manager)
+    {
+        if (is_array($listener)) {
+
+            foreach ($listener as $individualListener) {
+                $this->registerListener($event, $individualListener, $manager);
+            }
+
+            return;
+        }
+
+        if (!class_exists($listener, false)) {
+            throw new InvalidArgumentException("Listener {$listener} does not exist");
+        }
+
+        $manager->getEventManager()->addEventListener($event, new $listener);
+
+
     }
 
     /**

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -145,7 +145,6 @@ class EntityManagerFactory
     private function registerListener($event, $listener, EntityManagerInterface $manager)
     {
         if (is_array($listener)) {
-
             foreach ($listener as $individualListener) {
                 $this->registerListener($event, $individualListener, $manager);
             }
@@ -158,8 +157,6 @@ class EntityManagerFactory
         }
 
         $manager->getEventManager()->addEventListener($event, new $listener);
-
-
     }
 
     /**

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -289,6 +289,29 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('name', $manager->getEventManager()->getListeners()));
     }
 
+    public function test_can_set_multiple_listeners()
+    {
+        $this->disableDebugbar();
+        $this->disableSecondLevelCaching();
+        $this->disableCustomCacheNamespace();
+        $this->disableCustomFunctions();
+        $this->enableLaravelNamingStrategy();
+
+        $this->settings['events']['listeners'] = [
+            'name' => [
+                ListenerStub::class,
+                AnotherListenerStub::class
+            ]
+        ];
+
+        $manager = $this->factory->create($this->settings);
+
+        $this->assertEntityManager($manager);
+        $this->assertCount(1, $manager->getEventManager()->getListeners());
+        $this->assertTrue(array_key_exists('name', $manager->getEventManager()->getListeners()));
+        $this->assertCount(2, $manager->getEventManager()->getListeners('name'));
+    }
+
     public function test_can_set_subscribers()
     {
         $this->disableDebugbar();
@@ -528,6 +551,10 @@ class FilterStub
 }
 
 class ListenerStub
+{
+}
+
+class AnotherListenerStub
 {
 }
 


### PR DESCRIPTION
In 1.0 release each Doctrine event can only have one listener attached to it, but it would be helpful to be able to add many listeners to a single event (the same effect can currently be achieved by adding multiple subscribers). This PR should have no BC break, it checks if the listener passed is just a single class or an array and behaves appropriately.