### PR TITLE
Resolves event listeners and subscribers from the DI container

### DIFF
--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -16,6 +16,7 @@ use LaravelDoctrine\ORM\Configuration\Connections\ConnectionManager;
 use LaravelDoctrine\ORM\Configuration\LaravelNamingStrategy;
 use LaravelDoctrine\ORM\Configuration\MetaData\MetaDataManager;
 use LaravelDoctrine\ORM\Extensions\MappingDriverChain;
+use ReflectionException;
 
 class EntityManagerFactory
 {
@@ -136,7 +137,7 @@ class EntityManagerFactory
             }
         }
     }
-
+    
     /**
      * @param string                 $event
      * @param string|string[]        $listener
@@ -152,11 +153,17 @@ class EntityManagerFactory
             return;
         }
 
-        if (!class_exists($listener, false)) {
-            throw new InvalidArgumentException("Listener {$listener} does not exist");
+        try {
+            $resolvedListener = $this->container->make($listener);
+        } catch (ReflectionException $e) {
+            throw new InvalidArgumentException(
+                "Listener {$listener} could not be resolved: {$e->getMessage()}",
+                0,
+                $e
+            );
         }
 
-        $manager->getEventManager()->addEventListener($event, new $listener);
+        $manager->getEventManager()->addEventListener($event, $resolvedListener);
     }
 
     /**
@@ -167,11 +174,13 @@ class EntityManagerFactory
     {
         if (isset($settings['events']['subscribers'])) {
             foreach ($settings['events']['subscribers'] as $subscriber) {
-                if (!class_exists($subscriber, false)) {
-                    throw new InvalidArgumentException("Subscriber $subscriber does not exist");
+                try {
+                    $resolvedSubscriber = $this->container->make($subscriber);
+                } catch (ReflectionException $e) {
+                    throw new InvalidArgumentException("Listener {$subscriber} could not be resolved: {$e->getMessage()}");
                 }
 
-                $manager->getEventManager()->addEventSubscriber(new $subscriber);
+                $manager->getEventManager()->addEventSubscriber($resolvedSubscriber);
             }
         }
     }

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -137,7 +137,7 @@ class EntityManagerFactory
             }
         }
     }
-    
+
     /**
      * @param string                 $event
      * @param string|string[]        $listener

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -326,6 +326,30 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
         $this->assertCount(2, $manager->getEventManager()->getListeners('name'));
     }
 
+    public function test_setting_non_existent_listener_throws_exception()
+    {
+        $reflectionException = new ReflectionException();
+
+        $this->container->shouldReceive('make')
+                ->with('ClassDoesNotExist')
+                ->once()
+                ->andThrow($reflectionException);
+
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $this->disableDebugbar();
+        $this->disableSecondLevelCaching();
+        $this->disableCustomCacheNamespace();
+        $this->disableCustomFunctions();
+        $this->enableLaravelNamingStrategy();
+
+        $this->settings['events']['listeners'] = [
+            'name' => 'ClassDoesNotExist'
+        ];
+
+        $this->factory->create($this->settings);
+    }
+
     public function test_can_set_subscribers()
     {
         $this->container->shouldReceive('make')
@@ -348,6 +372,30 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
         $this->assertEntityManager($manager);
         $this->assertCount(1, $manager->getEventManager()->getListeners());
         $this->assertTrue(array_key_exists('onFlush', $manager->getEventManager()->getListeners()));
+    }
+
+    public function test_setting_non_existent_subscriber_throws_exception()
+    {
+        $reflectionException = new ReflectionException();
+
+        $this->container->shouldReceive('make')
+                        ->with('ClassDoesNotExist')
+                        ->once()
+                        ->andThrow($reflectionException);
+
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $this->disableDebugbar();
+        $this->disableSecondLevelCaching();
+        $this->disableCustomCacheNamespace();
+        $this->disableCustomFunctions();
+        $this->enableLaravelNamingStrategy();
+
+        $this->settings['events']['subscribers'] = [
+            'name' => 'ClassDoesNotExist'
+        ];
+
+        $this->factory->create($this->settings);
     }
 
     public function test_can_set_custom_naming_strategy()

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -272,6 +272,11 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
 
     public function test_can_set_listeners()
     {
+        $this->container->shouldReceive('make')
+                ->with(ListenerStub::class)
+                ->once()
+                ->andReturn(new ListenerStub());
+
         $this->disableDebugbar();
         $this->disableSecondLevelCaching();
         $this->disableCustomCacheNamespace();
@@ -291,6 +296,15 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
 
     public function test_can_set_multiple_listeners()
     {
+        $this->container->shouldReceive('make')
+                        ->with(ListenerStub::class)
+                        ->once()
+                        ->andReturn(new ListenerStub())
+                        ->shouldReceive('make')
+                        ->with(AnotherListenerStub::class)
+                        ->once()
+                        ->andReturn(new AnotherListenerStub());
+
         $this->disableDebugbar();
         $this->disableSecondLevelCaching();
         $this->disableCustomCacheNamespace();
@@ -314,6 +328,11 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
 
     public function test_can_set_subscribers()
     {
+        $this->container->shouldReceive('make')
+                ->with(SubscriberStub::class)
+                ->once()
+                ->andReturn(new SubscriberStub);
+
         $this->disableDebugbar();
         $this->disableSecondLevelCaching();
         $this->disableCustomCacheNamespace();


### PR DESCRIPTION
In 1.0 at the moment Listeners and Subscribers are instantiated by `new $listener`. This PR replaces this behaviour with usage of Laravel's container to resolve Listeners and Subscribers. This allows the container to automatically inject dependencies into Listeners and Subscribers.

Fixes #47 