### PR TITLE
Made the `Jsonable` trait compatible with Laravel's `Jsonable` interface

### DIFF
--- a/src/Serializers/JsonSerializer.php
+++ b/src/Serializers/JsonSerializer.php
@@ -26,11 +26,12 @@ class JsonSerializer
     /**
      * @param $entity
      *
+     * @param  int    $jsonEncodeOptions
      * @return string
      */
-    public function serialize($entity)
+    public function serialize($entity, $jsonEncodeOptions = 0)
     {
-        return $this->serializer->serialize($entity, 'json');
+        return $this->serializer->serialize($entity, 'json', ['json_encode_options' => $jsonEncodeOptions]);
     }
 
     /**

--- a/src/Serializers/Jsonable.php
+++ b/src/Serializers/Jsonable.php
@@ -5,11 +5,12 @@ namespace LaravelDoctrine\ORM\Serializers;
 trait Jsonable
 {
     /**
+     * @param  int    $options
      * @return string
      */
-    public function toJson()
+    public function toJson($options = 0)
     {
-        return (new JsonSerializer)->serialize($this);
+        return (new JsonSerializer)->serialize($this, $options);
     }
 
     /**

--- a/tests/Serializers/JsonSerializerTest.php
+++ b/tests/Serializers/JsonSerializerTest.php
@@ -15,11 +15,20 @@ class JsonSerializerTest extends PHPUnit_Framework_TestCase
         $this->serializer = new JsonSerializer;
     }
 
-    public function test_can_serialize_to_array()
+    public function test_can_serialize_to_json()
     {
-        $array = $this->serializer->serialize(new JsonableEntity);
+        $json = $this->serializer->serialize(new JsonableEntity);
 
-        $this->assertEquals('{"id":"IDVALUE","name":"NAMEVALUE"}', $array);
+        $this->assertJson($json);
+        $this->assertEquals('{"id":"IDVALUE","name":"NAMEVALUE","numeric":"1"}', $json);
+    }
+
+    public function test_can_serialize_to_json_with_numeric_check()
+    {
+        $json = $this->serializer->serialize(new JsonableEntity(), JSON_NUMERIC_CHECK);
+
+        $this->assertJson($json);
+        $this->assertEquals('{"id":"IDVALUE","name":"NAMEVALUE","numeric":1}', $json);
     }
 }
 
@@ -31,6 +40,8 @@ class JsonableEntity
 
     protected $name = 'NAMEVALUE';
 
+    protected $numeric = "1";
+
     public function getId()
     {
         return $this->id;
@@ -39,5 +50,10 @@ class JsonableEntity
     public function getName()
     {
         return $this->name;
+    }
+
+    public function getNumeric()
+    {
+        return $this->numeric;
     }
 }


### PR DESCRIPTION
Added the ability to pass options to the json serializer to make the definition of the trait `Jsonable` compatible with Laravel's `Jsonable` interface.

It would be nice to be able to return Laravel style collections from repositories. These include a `toJson` method, which looks for an object that implements `Illuminate\Contracts\Support\Jsonable`. In order to fulfil this interface we need to be able to accept Json options (such as `JSON_NUMERIC_CHECK`) in our trait.
