### PR TITLE
Allow specifying an extension for Yaml and Xml Metadata drivers

### DIFF
--- a/src/Configuration/MetaData/Xml.php
+++ b/src/Configuration/MetaData/Xml.php
@@ -14,7 +14,8 @@ class Xml extends MetaData
     public function resolve(array $settings = [])
     {
         return new XmlDriver(
-            array_get($settings, 'paths')
+            array_get($settings, 'paths'),
+            array_get($settings, 'extension', XmlDriver::DEFAULT_FILE_EXTENSION)
         );
     }
 }

--- a/src/Configuration/MetaData/Yaml.php
+++ b/src/Configuration/MetaData/Yaml.php
@@ -14,7 +14,8 @@ class Yaml extends MetaData
     public function resolve(array $settings = [])
     {
         return new YamlDriver(
-            array_get($settings, 'paths')
+            array_get($settings, 'paths'),
+            array_get($settings, 'extension', YamlDriver::DEFAULT_FILE_EXTENSION)
         );
     }
 }

--- a/tests/Configuration/MetaData/XmlTest.php
+++ b/tests/Configuration/MetaData/XmlTest.php
@@ -29,6 +29,25 @@ class XmlTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(XmlDriver::class, $resolved);
     }
 
+    public function test_can_specify_extension_without_error()
+    {
+        $resolved = $this->meta->resolve([
+            'paths'     => 'entities',
+            'extension' => '.orm.xml'
+        ]);
+
+        $this->assertInstanceOf(XmlDriver::class, $resolved);
+    }
+
+    public function test_can_not_specify_extension_without_error()
+    {
+        $resolved = $this->meta->resolve([
+            'paths'     => 'entities'
+        ]);
+
+        $this->assertInstanceOf(XmlDriver::class, $resolved);
+    }
+
     protected function tearDown()
     {
         m::close();

--- a/tests/Configuration/MetaData/YamlTest.php
+++ b/tests/Configuration/MetaData/YamlTest.php
@@ -29,6 +29,25 @@ class YamlTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(YamlDriver::class, $resolved);
     }
 
+    public function test_can_specify_extension_without_error()
+    {
+        $resolved = $this->meta->resolve([
+            'paths'     => 'entities',
+            'extension' => '.orm.yml'
+        ]);
+
+        $this->assertInstanceOf(YamlDriver::class, $resolved);
+    }
+
+    public function test_can_not_specify_extension_without_error()
+    {
+        $resolved = $this->meta->resolve([
+            'paths'     => 'entities'
+        ]);
+
+        $this->assertInstanceOf(YamlDriver::class, $resolved);
+    }
+
     protected function tearDown()
     {
         m::close();


### PR DESCRIPTION
This pull request allows the user to specify the extension used by the Xml and Yaml drivers.

BC break: No.   If the extension is not specified the doctrine default extension is used, so this will not be a bc break.

Use case:  Simplifies moving to this package if you were already using Doctrine directly with a custom extension.

Affects Documentation: Yes.  A configuration option is available called 'extension'.

I tested as well as I could, but there is not a way to view the extension once it is passed to the driver, and I cannot mock the driver class.