### PR TITLE
Add simplified xml and simplified yaml metadata drivers

### DIFF
--- a/src/Configuration/MetaData/SimplifiedXml.php
+++ b/src/Configuration/MetaData/SimplifiedXml.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace LaravelDoctrine\ORM\Configuration\MetaData;
+
+use Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver;
+
+class SimplifiedXml extends MetaData
+{
+    /**
+     * @param array $settings
+     *
+     * @return \Doctrine\Common\Persistence\Mapping\Driver\MappingDriver
+     */
+    public function resolve(array $settings = [])
+    {
+        return new SimplifiedXmlDriver(
+            array_get($settings, 'paths'),
+            array_get($settings, 'extension', SimplifiedXmlDriver::DEFAULT_FILE_EXTENSION)
+        );
+    }
+}

--- a/src/Configuration/MetaData/SimplifiedYaml.php
+++ b/src/Configuration/MetaData/SimplifiedYaml.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace LaravelDoctrine\ORM\Configuration\MetaData;
+
+use Doctrine\ORM\Mapping\Driver\SimplifiedYamlDriver;
+
+class SimplifiedYaml extends MetaData
+{
+    /**
+     * @param array $settings
+     *
+     * @return \Doctrine\Common\Persistence\Mapping\Driver\MappingDriver
+     */
+    public function resolve(array $settings = [])
+    {
+        return new SimplifiedYamlDriver(
+            array_get($settings, 'paths'),
+            array_get($settings, 'extension', SimplifiedYamlDriver::DEFAULT_FILE_EXTENSION)
+        );
+    }
+}

--- a/tests/Configuration/MetaData/SimplifiedXmlTest.php
+++ b/tests/Configuration/MetaData/SimplifiedXmlTest.php
@@ -20,10 +20,10 @@ class SimplifiedXmlTest extends PHPUnit_Framework_TestCase
     public function test_can_resolve()
     {
         $resolved = $this->meta->resolve([
-            'paths'   => ['entities' => 'App\Entities'],
-            'dev'     => true,
+            'paths'     => ['entities' => 'App\Entities'],
+            'dev'       => true,
             'extension' => '.xml',
-            'proxies' => ['path' => 'path']
+            'proxies'   => ['path' => 'path']
         ]);
 
         $this->assertInstanceOf(MappingDriver::class, $resolved);

--- a/tests/Configuration/MetaData/SimplifiedXmlTest.php
+++ b/tests/Configuration/MetaData/SimplifiedXmlTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver;
+use LaravelDoctrine\ORM\Configuration\MetaData\SimplifiedXml;
+use Mockery as m;
+
+class SimplifiedXmlTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SimplifiedXml
+     */
+    protected $meta;
+
+    protected function setUp()
+    {
+        $this->meta = new SimplifiedXml();
+    }
+
+    public function test_can_resolve()
+    {
+        $resolved = $this->meta->resolve([
+            'paths'   => ['entities' => 'App\Entities'],
+            'dev'     => true,
+            'extension' => '.xml',
+            'proxies' => ['path' => 'path']
+        ]);
+
+        $this->assertInstanceOf(MappingDriver::class, $resolved);
+        $this->assertInstanceOf(SimplifiedXmlDriver::class, $resolved);
+    }
+
+    protected function tearDown()
+    {
+        m::close();
+    }
+}

--- a/tests/Configuration/MetaData/SimplifiedYamlTest.php
+++ b/tests/Configuration/MetaData/SimplifiedYamlTest.php
@@ -20,10 +20,10 @@ class SimplifiedYamlTest extends PHPUnit_Framework_TestCase
     public function test_can_resolve()
     {
         $resolved = $this->meta->resolve([
-            'paths'   => ['entities' => 'App\Entities'],
-            'dev'     => true,
+            'paths'     => ['entities' => 'App\Entities'],
+            'dev'       => true,
             'extension' => '.yaml',
-            'proxies' => ['path' => 'path']
+            'proxies'   => ['path' => 'path']
         ]);
 
         $this->assertInstanceOf(MappingDriver::class, $resolved);

--- a/tests/Configuration/MetaData/SimplifiedYamlTest.php
+++ b/tests/Configuration/MetaData/SimplifiedYamlTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\ORM\Mapping\Driver\SimplifiedYamlDriver;
+use LaravelDoctrine\ORM\Configuration\MetaData\SimplifiedYaml;
+use Mockery as m;
+
+class SimplifiedYamlTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SimplifiedYaml
+     */
+    protected $meta;
+
+    protected function setUp()
+    {
+        $this->meta = new SimplifiedYaml();
+    }
+
+    public function test_can_resolve()
+    {
+        $resolved = $this->meta->resolve([
+            'paths'   => ['entities' => 'App\Entities'],
+            'dev'     => true,
+            'extension' => '.yaml',
+            'proxies' => ['path' => 'path']
+        ]);
+
+        $this->assertInstanceOf(MappingDriver::class, $resolved);
+        $this->assertInstanceOf(SimplifiedYamlDriver::class, $resolved);
+    }
+
+    protected function tearDown()
+    {
+        m::close();
+    }
+}


### PR DESCRIPTION
This pull request adds the [SimplifiedXml](http://doctrine-orm.readthedocs.org/projects/doctrine-orm/en/latest/reference/xml-mapping.html#simplified-xml-driver) and [simplifiedYaml](http://doctrine-orm.readthedocs.org/en/latest/reference/yaml-mapping.html#simplified-yaml-driver) drivers.

BC break: No.  These classes are only used if the user specifies `'meta' => 'simplified_xml'` or `'meta' => 'simplified_yaml'` in the config file. 

Use case: Simplifies moving to this package if you were already using Doctrine directly with the SimplifiedXml or SimplifiedYaml drivers.

Affects Documentation: Yes. [This page](http://www.laraveldoctrine.org/docs/1.0/orm/meta-data-configuration) will need to be updated with the new drivers.