### PR TITLE
Add repository_factory config option

### DIFF
--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -105,6 +105,7 @@ class EntityManagerFactory
         $this->configureProxies($settings, $configuration);
         $this->setCustomMappingDriverChain($settings, $configuration);
         $this->registerPaths($settings, $configuration);
+        $this->setRepositoryFactory($settings, $configuration);
 
         $configuration->setDefaultRepositoryClassName(
             array_get($settings, 'repository', EntityRepository::class)
@@ -212,6 +213,19 @@ class EntityManagerFactory
         $configuration->getMetadataDriverImpl()->addPaths(
             array_get($settings, 'paths', [])
         );
+    }
+
+    /**
+     * @param array         $settings
+     * @param Configuration $configuration
+     */
+    protected function setRepositoryFactory($settings, Configuration $configuration)
+    {
+        if (array_get($settings, 'repository_factory', false)) {
+            $configuration->setRepositoryFactory(
+                $this->container->make(array_get($settings, 'repository_factory', false))
+            );
+        }
     }
 
     /**

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -23,16 +23,17 @@ use LaravelDoctrine\ORM\Configuration\MetaData\MetaDataManager;
 use LaravelDoctrine\ORM\EntityManagerFactory;
 use LaravelDoctrine\ORM\Loggers\Logger;
 use Mockery as m;
+use Mockery\Mock;
 
 class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var CacheManager
+     * @var CacheManager|Mock
      */
     protected $cache;
 
     /**
-     * @var Repository
+     * @var Repository|Mock
      */
     protected $config;
 
@@ -47,7 +48,7 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
     protected $meta;
 
     /**
-     * @var Container
+     * @var Container|Mock
      */
     protected $container;
 
@@ -57,7 +58,7 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
     protected $factory;
 
     /**
-     * @var Configuration
+     * @var Configuration|Mock
      */
     protected $configuration;
 
@@ -435,6 +436,31 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
         $this->assertEntityManager($manager);
         $this->assertInstanceOf(Decorator::class, $manager);
         $this->assertInstanceOf(EntityManagerDecorator::class, $manager);
+    }
+
+    public function test_can_set_repository_factory()
+    {
+        $this->disableDebugbar();
+        $this->disableSecondLevelCaching();
+        $this->disableCustomCacheNamespace();
+        $this->disableCustomFunctions();
+        $this->enableLaravelNamingStrategy();
+
+        $this->settings['repository_factory'] = 'RepositoryFactory';
+
+        $repositoryFactory = m::mock(RepositoryFactory::class);
+
+        $this->container->shouldReceive('make')
+            ->with('RepositoryFactory')
+            ->once()->andReturn($repositoryFactory);
+
+        $this->configuration->shouldReceive('setRepositoryFactory')
+            ->once()
+            ->with($repositoryFactory);
+
+        $manager = $this->factory->create($this->settings);
+
+        $this->assertEntityManager($manager);
     }
 
     /**


### PR DESCRIPTION
This PR adds a  config key `repository_factory` which can be set to the class name of the repository factory you would like to use.  If not set, Doctrine will continue to use the DefaultRepositoryFactory.

This option must be set on the Doctrine\ORM\Configuration object before the EntityManager is constructed because [Doctrine sets the entity manager's repository factory property on construction](https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/EntityManager.php#L159).