### PR TITLE
Fix typo in available cache types

### DIFF
--- a/src/Console/ConfigMigrations/templates/laraveldoctrine/master.blade.php
+++ b/src/Console/ConfigMigrations/templates/laraveldoctrine/master.blade.php
@@ -82,7 +82,7 @@ return [
         | Configure meta-data, query and result caching here.
         | Optionally you can enable second level caching.
         |
-        | Available: acp|array|file|memcached|redis
+        | Available: apc|array|file|memcached|redis
         |
         */
         'cache' => {{$cache}}


### PR DESCRIPTION
Just a little typo: "acp" should be "apc". :+1:
