### PR TITLE
Flipped boolean value returned by isTransient();

### DIFF
--- a/src/Configuration/MetaData/Config/ConfigDriver.php
+++ b/src/Configuration/MetaData/Config/ConfigDriver.php
@@ -39,7 +39,7 @@ class ConfigDriver extends YamlDriver implements MappingDriver
      */
     public function isTransient($className)
     {
-        return array_key_exists($className, $this->mappings);
+        return !array_key_exists($className, $this->mappings);
     }
 
     /**

--- a/tests/Configuration/MetaData/ConfigDriverTest.php
+++ b/tests/Configuration/MetaData/ConfigDriverTest.php
@@ -42,8 +42,8 @@ class ConfigDriverTest extends PHPUnit_Framework_TestCase
 
     public function test_can_check_if_is_transient()
     {
-        $this->assertTrue($this->driver->isTransient('App\User'));
-        $this->assertFalse($this->driver->isTransient('App\NonExisting'));
+        $this->assertFalse($this->driver->isTransient('App\User'));
+        $this->assertTrue($this->driver->isTransient('App\NonExisting'));
     }
 
     public function test_can_element()


### PR DESCRIPTION
Fixes table inheritance ('inheritanceType' => 'JOINED'). A class is transient if it is NOT found in $this->mappings. This was causing parent classes in table inheritance pattern to fail to be loaded into the metadata, hence properties were not inheriting properly to child classes.

Fun to track down ... crucially, AbstractClassMetadataFactory->getParentClasses() was not returning the parent class of my extending class, ultimately because isTransient() was returning TRUE. Without the parent class info, doctrine can't properly map the inheritance stuff onto the extending classes.
