### PR TITLE
Allow specifying the EntityManager used by EntityManagerFactory

### DIFF
--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -111,10 +111,7 @@ class EntityManagerFactory
             array_get($settings, 'repository', EntityRepository::class)
         );
 
-        $manager = EntityManager::create(
-            $connection,
-            $configuration
-        );
+        $manager = $this->getEntityManager($settings, $connection, $configuration);
 
         $manager = $this->decorateManager($settings, $manager);
 
@@ -371,5 +368,26 @@ class EntityManagerFactory
         }
 
         return $this->config->get($key);
+    }
+
+    /**
+     * @param array $settings
+     * @param       $connection
+     * @param       $configuration
+     *
+     * @return EntityManager
+     * @throws \Doctrine\ORM\ORMException
+     */
+    protected function getEntityManager(array $settings = [], $connection, $configuration)
+    {
+        if ($manager = array_get($settings, 'entity_manager', false)) {
+            if (!class_exists($manager)) {
+                throw new InvalidArgumentException("EntityManager {$manager} does not exist");
+            }
+
+            return $manager::create($connection, $configuration);
+        }
+
+        return EntityManager::create($connection, $configuration);
     }
 }

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -463,6 +463,30 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
         $this->assertEntityManager($manager);
     }
 
+    public function test_can_set_entity_manager()
+    {
+        $this->disableDebugbar();
+        $this->disableSecondLevelCaching();
+        $this->disableCustomCacheNamespace();
+        $this->disableCustomFunctions();
+        $this->enableLaravelNamingStrategy();
+
+
+        $manager = m::mock('CustomEntityManager');
+        $manager
+            ->shouldReceive('create')
+            ->once()
+            ->andReturnUsing(function ($connection, $configuration) {
+                return \Doctrine\ORM\EntityManager::create($connection, $configuration);
+            });
+
+        $this->settings['entity_manager'] = get_class($manager);
+
+        $manager = $this->factory->create($this->settings);
+
+        $this->assertInstanceOf(EntityManagerInterface::class, $manager);
+    }
+
     /**
      * MOCKS
      */


### PR DESCRIPTION
This PR adds an optional config key 'entity_manager'.  If specified, the provided class will be used instead of the default.

Use case:

Adding the 'entity_manager' option would allow the end user to override the behavior of the entity manager returned by the EntityManagerFactory.

I personally use a custom manager similar to [https://github.com/laravel-doctrine/orm/commit/bfa8e471238bddbbd603bf9c7e0d84dffd56216d](these changes on master) to specify a custom default hydrator.

A config option would allow changing the hydration mode, as well as changing any configuration options before the Entity Manager is created.

This would also allow users who do not want to use Illuminate Collections to specify the default Entity Manager.

Requires Documentation Update: Yes.

BC Break: No.  This should also merge cleanly with the changes in master, since master only changed the use statement in the EntityManagerFactory class.
