### PR TITLE
resetManager() does not clear getManager()'s cache

### DIFF
--- a/src/IlluminateRegistry.php
+++ b/src/IlluminateRegistry.php
@@ -274,6 +274,8 @@ final class IlluminateRegistry implements ManagerRegistry
         $this->resetService(
             $this->getManagerBindingName($this->managers[$name])
         );
+
+        unset($this->managersMap[$name]);
     }
 
     /**

--- a/tests/IlluminateRegistryTest.php
+++ b/tests/IlluminateRegistryTest.php
@@ -330,6 +330,26 @@ class IlluminateRegistryTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Namespace', $this->registry->getAliasNamespace('Alias'));
     }
 
+    /**
+     * Verify that getManager() returns a new instance after a call to resetManager().
+     */
+    public function test_get_manager_after_reset_should_return_new_manager() {
+        $this->container->shouldReceive('singleton');
+        $this->registry->addManager('default');
+
+        $this->container->shouldReceive('make')
+            ->with('doctrine.managers.default')
+            ->andReturn(new stdClass(), new stdClass());
+
+        $first = $this->registry->getManager();
+
+        $this->container->shouldReceive('forgetInstance');
+        $this->registry->resetManager();
+
+        $second = $this->registry->getManager();
+        $this->assertNotSame($first, $second);
+    }
+
     protected function tearDown()
     {
         m::close();

--- a/tests/IlluminateRegistryTest.php
+++ b/tests/IlluminateRegistryTest.php
@@ -333,7 +333,8 @@ class IlluminateRegistryTest extends PHPUnit_Framework_TestCase
     /**
      * Verify that getManager() returns a new instance after a call to resetManager().
      */
-    public function test_get_manager_after_reset_should_return_new_manager() {
+    public function test_get_manager_after_reset_should_return_new_manager()
+    {
         $this->container->shouldReceive('singleton');
         $this->registry->addManager('default');
 


### PR DESCRIPTION
resetManager() does not clear getManager()'s cache (the managersMap array). This PR calls clears the cache so that a new manager is generated on the next call to getManager().
