### PR TITLE
Changed behaviour of extension booting

### DIFF
--- a/src/Http/Middleware/BootExtensionsMiddleware.php
+++ b/src/Http/Middleware/BootExtensionsMiddleware.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace LaravelDoctrine\ORM\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use LaravelDoctrine\ORM\Extensions\ExtensionManager;
+
+class BootExtensionsMiddleware
+{
+    /**
+     * @var ExtensionManager
+     */
+    private $extensionManager;
+
+    public function __construct(ExtensionManager $extensionManager)
+    {
+        $this->extensionManager = $extensionManager;
+    }
+
+    /**
+     * @param $request
+     * @param  Closure $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $this->extensionManager->boot();
+
+        return $next($request);
+    }
+}

--- a/tests/Http/Middleware/BootExtensionsMiddlewareTest.php
+++ b/tests/Http/Middleware/BootExtensionsMiddlewareTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use LaravelDoctrine\ORM\Http\Middleware\BootExtensionsMiddleware;
+use Mockery as m;
+
+class BootExtensionsMiddlewareTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testHandle()
+    {
+        $kernelMock = m::mock(LaravelDoctrine\ORM\Extensions\ExtensionManager::class)
+            ->shouldReceive('boot')
+            ->once()
+            ->getMock();
+
+        $requestMock = m::mock(Illuminate\Http\Request::class);
+
+        $called = false;
+
+        $nextMock = function () use (&$called) {
+            $called = true;
+        };
+
+        /** @noinspection PhpParamsInspection */
+        $middleware = new BootExtensionsMiddleware($kernelMock);
+
+        /** @noinspection PhpParamsInspection */
+        $middleware->handle($requestMock, $nextMock);
+
+        $this->assertTrue($called);
+    }
+}


### PR DESCRIPTION
The extension manager is booted immediately when in CLI or is booted from a middleware for HTTP requests. This change has not been tested against a Laravel install
