### PR TITLE
Move the binding of `validation.presence` into a deferred provider.

### DIFF
--- a/src/DoctrineServiceProvider.php
+++ b/src/DoctrineServiceProvider.php
@@ -31,7 +31,6 @@ use LaravelDoctrine\ORM\Exceptions\ExtensionNotFound;
 use LaravelDoctrine\ORM\Extensions\ExtensionManager;
 use LaravelDoctrine\ORM\Http\Middleware\BootExtensions;
 use LaravelDoctrine\ORM\Testing\Factory as EntityFactory;
-use LaravelDoctrine\ORM\Validation\DoctrinePresenceVerifier;
 
 class DoctrineServiceProvider extends ServiceProvider
 {
@@ -66,7 +65,7 @@ class DoctrineServiceProvider extends ServiceProvider
         $this->registerEntityManager();
         $this->registerClassMetaDataFactory();
         $this->registerExtensions();
-        $this->registerPresenceVerifier();
+        $this->registerPresenceVerifierProvider();
         $this->registerConsoleCommands();
         $this->registerCustomTypes();
         $this->registerEntityFactory();
@@ -189,11 +188,11 @@ class DoctrineServiceProvider extends ServiceProvider
     }
 
     /**
-     * Register the validation presence verifier
+     * Register the deferred service provider for the validation presence verifier
      */
-    protected function registerPresenceVerifier()
+    protected function registerPresenceVerifierProvider()
     {
-        $this->app->singleton('validation.presence', DoctrinePresenceVerifier::class);
+        $this->app->register(PresenceVerifierProvider::class);
     }
 
     /**

--- a/src/PresenceVerifierProvider.php
+++ b/src/PresenceVerifierProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+
+namespace LaravelDoctrine\ORM;
+
+use Illuminate\Support\ServiceProvider;
+use LaravelDoctrine\ORM\Validation\DoctrinePresenceVerifier;
+
+class PresenceVerifierProvider extends ServiceProvider
+{
+    /**
+     * In Laravel 5.2 Validation became a deferred service, so in order to override it we must do so from a
+     * deferred provider.
+     *
+     * @var bool
+     */
+    protected $deferred = true;
+
+    /**
+     * Replace Laravel's presence validator with a Doctrine one. This lets us reference Entities through
+     * classname.property rather than table.column.
+     */
+    public function register()
+    {
+        $this->app->singleton('validation.presence', DoctrinePresenceVerifier::class);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function provides()
+    {
+        return [
+            'validation.presence'
+        ];
+    }
+}


### PR DESCRIPTION
The Laravel implementation is now bound in a deferred provider, so cannot be overridden by a normal SP.
