### PR TITLE
Replace direct binding of `auth.password.broker` with our own implementation of its manager class.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,11 @@ composer.phar
 composer.lock
 .DS_Store
 .php_cs.cache
+/coverage
 
 /tests/Stubs/storage/framework/views/*
 !/tests/Stubs/storage/framework/views/.gitkeep
 /tests/Stubs/storage/doctrine.generated.php
 .idea
+.phpstorm.meta.php
 laravel-doctrine-orm.iml

--- a/src/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Auth/Passwords/PasswordBrokerManager.php
@@ -1,0 +1,46 @@
+<?php
+
+
+namespace LaravelDoctrine\ORM\Auth\Passwords;
+
+use Closure;
+use Illuminate\Auth\Passwords\PasswordBrokerManager as LaravelPasswordBrokerManager;
+use Illuminate\Contracts\Auth\PasswordBrokerFactory as FactoryContract;
+
+class PasswordBrokerManager extends LaravelPasswordBrokerManager implements FactoryContract
+{
+    /**
+     * @var Closure[]
+     */
+    protected $customTokenCreators = [];
+
+    /**
+     * Register a custom provider creator Closure.
+     *
+     * @param  string  $name
+     * @param  Closure $callback
+     * @return $this
+     */
+    public function provider($name, Closure $callback)
+    {
+        $this->customProviderCreators[$name] = $callback;
+    }
+
+    public function tokenRepository($driver, Closure $callback)
+    {
+        $this->customTokenCreators[$driver] = $callback;
+    }
+
+    public function createTokenRepository(array $config)
+    {
+        $providerConfig = $this->app['config']['auth.providers.' . $config['provider']];
+
+        if (isset($this->customTokenCreators[$providerConfig['driver']])) {
+            return call_user_func(
+                $this->customTokenCreators[$providerConfig['driver']], $this->app, $config
+            );
+        }
+
+        return parent::createTokenRepository($config);
+    }
+}

--- a/tests/Auth/Passwords/PasswordBrokerManagerTest.php
+++ b/tests/Auth/Passwords/PasswordBrokerManagerTest.php
@@ -1,0 +1,188 @@
+<?php
+
+use Illuminate\Auth\Passwords\PasswordBroker;
+use Illuminate\Auth\Passwords\PasswordBrokerManager as LaravelBrokerManager;
+use Illuminate\Auth\Passwords\TokenRepositoryInterface;
+use Illuminate\Contracts\Auth\PasswordBrokerFactory as FactoryContract;
+use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Contracts\Foundation\Application;
+use LaravelDoctrine\ORM\Auth\Passwords\PasswordBrokerManager;
+use Mockery as m;
+
+class PasswordBrokerManagerTest extends PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->app = m::mock(Application::class);
+    }
+
+    public function test_init_broker_manager()
+    {
+        $manager = new PasswordBrokerManager($this->app);
+
+        $this->assertInstanceOf(FactoryContract::class, $manager);
+        $this->assertInstanceOf(LaravelBrokerManager::class, $manager);
+    }
+
+    public function test_can_add_custom_provider()
+    {
+        $this->app                                  = [];
+        $this->app['config']['auth.providers.test'] = ['driver' => 'test'];
+
+        $manager = new PasswordBrokerManager($this->app);
+
+        $manager->provider('test', function ($app, $config) {
+            return new TestUserProvider;
+        });
+
+        $provider = $manager->createUserProvider('test');
+
+        $this->assertInstanceOf(TestUserProvider::class, $provider, 'The manager should use provided closure to make a provider');
+    }
+
+    public function test_can_add_custom_token_repository()
+    {
+        $this->app                                  = [];
+        $this->app['config']['auth.providers.test'] = ['driver' => 'test'];
+        $this->app['config']['auth.passwords.test'] = [
+            'provider' => 'test',
+            'email'    => 'email',
+            'table'    => 'table',
+            'expire'   => 60
+        ];
+        $this->app['mailer'] = m::mock(Illuminate\Contracts\Mail\Mailer::class);
+
+        $manager = new PasswordBrokerManager($this->app);
+
+        $manager->provider('test', function ($app, $config) {
+            return new TestUserProvider;
+        });
+
+        $manager->tokenRepository('test', function ($app, $config) {
+            return new TestTokenRepository;
+        });
+
+        $broker = $manager->broker('test');
+        $tokens = $this->extractTokens($broker);
+
+        $this->assertInstanceOf(PasswordBroker::class, $broker);
+        $this->assertInstanceOf(TestTokenRepository::class, $tokens);
+    }
+
+    private function extractTokens($broker)
+    {
+        $reflectionClass = new ReflectionClass(get_class($broker));
+        $tokens          = $reflectionClass->getProperty('tokens');
+        $tokens->setAccessible(true);
+
+        return $tokens->getValue($broker);
+    }
+}
+
+class TestTokenRepository implements TokenRepositoryInterface
+{
+    /**
+     * Create a new token.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword $user
+     * @return string
+     */
+    public function create(\Illuminate\Contracts\Auth\CanResetPassword $user)
+    {
+        //
+    }
+
+    /**
+     * Determine if a token record exists and is valid.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword $user
+     * @param  string                                      $token
+     * @return bool
+     */
+    public function exists(\Illuminate\Contracts\Auth\CanResetPassword $user, $token)
+    {
+        //
+    }
+
+    /**
+     * Delete a token record.
+     *
+     * @param  string $token
+     * @return void
+     */
+    public function delete($token)
+    {
+        //
+    }
+
+    /**
+     * Delete expired tokens.
+     *
+     * @return void
+     */
+    public function deleteExpired()
+    {
+        //
+    }
+}
+
+class TestUserProvider implements UserProvider
+{
+    /**
+     * Retrieve a user by their unique identifier.
+     *
+     * @param  mixed                                           $identifier
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    public function retrieveById($identifier)
+    {
+        //
+    }
+
+    /**
+     * Retrieve a user by their unique identifier and "remember me" token.
+     *
+     * @param  mixed                                           $identifier
+     * @param  string                                          $token
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    public function retrieveByToken($identifier, $token)
+    {
+        //
+    }
+
+    /**
+     * Update the "remember me" token for the given user in storage.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable $user
+     * @param  string                                     $token
+     * @return void
+     */
+    public function updateRememberToken(\Illuminate\Contracts\Auth\Authenticatable $user, $token)
+    {
+        //
+    }
+
+    /**
+     * Retrieve a user by the given credentials.
+     *
+     * @param  array                                           $credentials
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    public function retrieveByCredentials(array $credentials)
+    {
+        //
+    }
+
+    /**
+     * Validate a user against the given credentials.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable $user
+     * @param  array                                      $credentials
+     * @return bool
+     */
+    public function validateCredentials(\Illuminate\Contracts\Auth\Authenticatable $user, array $credentials)
+    {
+        //
+    }
+}


### PR DESCRIPTION
This is a potential fix for #116 

Sorry @patrickbrouwers but I've not done any end-end testing on this, I've still not got a test installation setup for this sort of stuff and we don't use passwords.

 In 1.1 the definition of the password reset broker is not compatible with Laravel 5.2. As part of fixing this I've decided to extend Laravel's `PasswordBrokerManager` so that we can bind our own token repository into it and then use it as is.

 Extending the manager seems fairly fragile, but there's no other way of forcing a different token repository in. I'm considering doing something similar as an upstream pull request to Laravel which means we wouldn't have to rely on extending this class.
