### PR TITLE
[FIX] Fixing password broker which was returning NULL instead of the entity…

### DIFF
--- a/src/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Auth/Passwords/PasswordBrokerManager.php
@@ -2,7 +2,7 @@
 
 namespace LaravelDoctrine\ORM\Auth\Passwords;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\EntityManagerInterface;
 
 class PasswordBrokerManager extends \Illuminate\Auth\Passwords\PasswordBrokerManager
 {
@@ -16,7 +16,7 @@ class PasswordBrokerManager extends \Illuminate\Auth\Passwords\PasswordBrokerMan
     protected function createTokenRepository(array $config)
     {
         return new DoctrineTokenRepository(
-            $this->app->make(ManagerRegistry::class)->getManagerForClass(PasswordReminder::class),
+            $this->app->make(EntityManagerInterface::class),
             $this->app['config']['app.key'],
             $config['expire']
         );


### PR DESCRIPTION
The password broker wasn't getting a valid entity manager when creating the DoctrineTokenRepository object.

I've updated the class to use Doctrine\ORM\EntityManagerInterface which appears to have solved the problem.
