### PR TITLE
[FIX] Add exit codes to commands

### DIFF
--- a/src/Console/EnsureProductionSettingsCommand.php
+++ b/src/Console/EnsureProductionSettingsCommand.php
@@ -43,7 +43,7 @@ class EnsureProductionSettingsCommand extends Command
                 $this->error('Error for ' . $name . ' entity manager');
                 $this->error($e->getMessage());
 
-                return;
+                return 1;
             }
 
             $this->comment('Environment for <info>' . $name . '</info> entity manager is correctly configured for production.');

--- a/src/Console/InfoCommand.php
+++ b/src/Console/InfoCommand.php
@@ -31,7 +31,7 @@ class InfoCommand extends Command
     public function fire(ManagerRegistry $registry)
     {
         $names = $this->option('em') ? [$this->option('em')] : $registry->getManagerNames();
-        $exit = 0;
+        $exit  = 0;
 
         foreach ($names as $name) {
             $em = $registry->getManager($name);

--- a/src/Console/InfoCommand.php
+++ b/src/Console/InfoCommand.php
@@ -31,6 +31,7 @@ class InfoCommand extends Command
     public function fire(ManagerRegistry $registry)
     {
         $names = $this->option('em') ? [$this->option('em')] : $registry->getManagerNames();
+        $exit = 0;
 
         foreach ($names as $name) {
             $em = $registry->getManager($name);
@@ -56,8 +57,12 @@ class InfoCommand extends Command
                     $this->comment("<error>[FAIL]</error> " . $entityClassName);
                     $this->comment(sprintf("<comment>%s</comment>", $e->getMessage()));
                     $this->comment('');
+
+                    $exit = 1;
                 }
             }
         }
+
+        return $exit;
     }
 }

--- a/src/Console/SchemaDropCommand.php
+++ b/src/Console/SchemaDropCommand.php
@@ -33,6 +33,7 @@ class SchemaDropCommand extends Command
         $this->error('ATTENTION: This operation should not be executed in a production environment.');
 
         $names = $this->option('em') ? [$this->option('em')] : $registry->getManagerNames();
+        $exit = 0;
 
         foreach ($names as $name) {
             $em   = $registry->getManager($name);
@@ -77,10 +78,14 @@ class SchemaDropCommand extends Command
                         $this->getName()));
                     $this->comment(sprintf('    <info>php artisan %s --sql</info> to dump the SQL statements to the screen',
                         $this->getName()));
+
+                    $exit = 1;
                 } else {
                     $this->error('Nothing to drop. The database is empty!');
                 }
             }
         }
+
+        return $exit;
     }
 }

--- a/src/Console/SchemaDropCommand.php
+++ b/src/Console/SchemaDropCommand.php
@@ -33,7 +33,7 @@ class SchemaDropCommand extends Command
         $this->error('ATTENTION: This operation should not be executed in a production environment.');
 
         $names = $this->option('em') ? [$this->option('em')] : $registry->getManagerNames();
-        $exit = 0;
+        $exit  = 0;
 
         foreach ($names as $name) {
             $em   = $registry->getManager($name);

--- a/src/Console/SchemaUpdateCommand.php
+++ b/src/Console/SchemaUpdateCommand.php
@@ -85,5 +85,7 @@ class SchemaUpdateCommand extends Command
             $this->comment(sprintf('    <info>php artisan %s --sql</info> to dump the SQL statements to the screen',
                 $this->getName()));
         }
+
+        return 1;
     }
 }

--- a/src/Console/SchemaValidateCommand.php
+++ b/src/Console/SchemaValidateCommand.php
@@ -30,7 +30,7 @@ class SchemaValidateCommand extends Command
     public function fire(ManagerRegistry $registry)
     {
         $names = $this->option('em') ? [$this->option('em')] : $registry->getManagerNames();
-        $exit = 0;
+        $exit  = 0;
 
         foreach ($names as $name) {
             $em        = $registry->getManager($name);

--- a/src/Console/SchemaValidateCommand.php
+++ b/src/Console/SchemaValidateCommand.php
@@ -30,6 +30,7 @@ class SchemaValidateCommand extends Command
     public function fire(ManagerRegistry $registry)
     {
         $names = $this->option('em') ? [$this->option('em')] : $registry->getManagerNames();
+        $exit = 0;
 
         foreach ($names as $name) {
             $em        = $registry->getManager($name);
@@ -49,6 +50,8 @@ class SchemaValidateCommand extends Command
                         $this->message('* ' . $errorMessage, 'red');
                     }
                 }
+
+                $exit += 1;
             } else {
                 $this->info('[Mapping]  OK - The mapping files are correct.');
             }
@@ -57,9 +60,13 @@ class SchemaValidateCommand extends Command
                 $this->comment('Database] SKIPPED - The database was not checked for synchronicity.');
             } elseif (!$validator->schemaInSyncWithMetadata()) {
                 $this->error('[Database] FAIL - The database schema is not in sync with the current mapping file.');
+
+                $exit += 2;
             } else {
                 $this->info('[Database] OK - The database schema is in sync with the mapping files.');
             }
         }
+
+        return $exit;
     }
 }


### PR DESCRIPTION
### Changes proposed in this pull request:
- Add exit codes for commands so third party tools can handle them

At the moment these commands are failing silently because external tools don't know when a command failed or succeeded. By returning an exit code (> 0) tools like CI tools etc can handle these commands properly.

To give a very specific example, we use CircleCI to check the schema validate command to see if it produced any SQL so we know if our mappings are ok. By adding the exit codes CircleCI knows when the command failed or succeeded.

I've tried porting the logic from the Doctrine commands as best as I could. Because you're using multiple managers, the implementation may vary slightly. 

I'm not really sure if this is "breaking" or not. People using these commands in tools like CircleCI may experience different behaviour in those tools when this gets merged. Builds may suddenly fail because a different exit code is returned. However, I do think this is preferred behaviour.

Thanks for considering!
