### PR TITLE
[FIX] Improvement/Fix  on artisan commands.

### DIFF
--- a/src/Console/GenerateEntitiesCommand.php
+++ b/src/Console/GenerateEntitiesCommand.php
@@ -52,7 +52,7 @@ class GenerateEntitiesCommand extends Command
             $metadatas = $cmf->getAllMetadata();
             $metadatas = MetadataFilter::filter($metadatas, $this->option('filter'));
 
-            $destPath = base_path('app/Entities');
+            $destPath = base_path($this->argument('dest-path') ?:'app/Entities');
 
             if (!is_dir($destPath)) {
                 mkdir($destPath, 0777, true);

--- a/src/Console/MappingImportCommand.php
+++ b/src/Console/MappingImportCommand.php
@@ -20,7 +20,8 @@ class MappingImportCommand extends Command
     {dest-path? : Location the mapping files should be imported to}
     {--em=default : Info for a specific entity manager }
     {--filter : A string pattern used to match entities that should be mapped}
-    {--force= : Force to overwrite existing mapping files}';
+    {--force= : Force to overwrite existing mapping files}
+    {--namespace= : Namespace to use}';
 
     /**
      * The console command description.
@@ -54,6 +55,13 @@ class MappingImportCommand extends Command
         }
 
         $databaseDriver = new DatabaseDriver($em->getConnection()->getSchemaManager());
+
+        // set namespace that will be used to generate metadata files
+        $namespace = $this->option('namespace');
+        if ($namespace) {
+            $databaseDriver->setNamespace($namespace);
+        }
+
         $em->getConfiguration()->setMetadataDriverImpl($databaseDriver);
 
         $cmf = new DisconnectedClassMetadataFactory();


### PR DESCRIPTION
### Changes proposed in this pull request:
- "doctrine:mapping:import" (improvement)
  added ability to create mapping files under a namespace
- "doctrine:generate:entities" (bug fix)
  option "dest-path" is now used as parent folder when entities are generated.
### Example of use:

Generate doctrine mapping files:
**`php artisan doctrine:mapping:import yaml --namespace App\Entities\`**
Generate doctrine entities:
**`php artisan doctrine:generate:entities .\`**
