### PR TITLE
[FIX] Use configuration defined path instead of hard-coded value for defaul…

### DIFF
--- a/src/Console/GenerateEntitiesCommand.php
+++ b/src/Console/GenerateEntitiesCommand.php
@@ -51,8 +51,8 @@ class GenerateEntitiesCommand extends Command
             $cmf->setEntityManager($em);
             $metadatas = $cmf->getAllMetadata();
             $metadatas = MetadataFilter::filter($metadatas, $this->option('filter'));
-
-            $destPath = base_path($this->argument('dest-path') ?:'app/Entities');
+			
+            $destPath = base_path($this->argument('dest-path') ? $this->argument('dest-path') : current(config("doctrine.managers.{$name}.paths")));
 
             if (!is_dir($destPath)) {
                 mkdir($destPath, 0777, true);

--- a/src/Console/MappingImportCommand.php
+++ b/src/Console/MappingImportCommand.php
@@ -40,7 +40,7 @@ class MappingImportCommand extends Command
         $emName = $this->option('em');
         $em     = $registry->getManager($emName);
 
-        $destPath = base_path($this->argument('dest-path') ? $this->argument('dest-path') : 'app/Mappings');
+        $destPath = $this->argument('dest-path') ? base_path($this->argument('dest-path')) : key(config("doctrine.managers.{$emName}.paths"));
 
         $type = $this->argument('mapping-type');
 


### PR DESCRIPTION
Use configuration defined path instead of hard-coded value for default destination path for writing imported mapping-files. see [issue #151](https://github.com/laravel-doctrine/orm/issues/151)
