### PR TITLE
[FEATURE] Add read write connection support

### DIFF
--- a/src/Utilities/ArrayUtil.php
+++ b/src/Utilities/ArrayUtil.php
@@ -8,4 +8,14 @@ class ArrayUtil
     {
         return isset($var) ? $var : $default;
     }
+
+    /**
+     * @param array $array
+     *
+     * @return string
+     */
+    public static function hashArray(array $array)
+    {
+        return md5(json_encode($array));
+    }
 }

--- a/src/Utilities/MasterSlaveConfigParser.php
+++ b/src/Utilities/MasterSlaveConfigParser.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace LaravelDoctrine\ORM\Utilities;
+
+use UnexpectedValueException;
+
+class MasterSlaveConfigParser
+{
+    /**
+     * @param array $config
+     *
+     * @throws UnexpectedValueException If config not contains valid read / write configuration.
+     *
+     * @return array If config is not valid for parse.
+     *
+     */
+    public static function parseConfig(array $config)
+    {
+        if ( ! self::hasValidConfig($config)) {
+            throw new UnexpectedValueException('Config not contains configuration for master/slave setup.');
+        }
+
+        $masterSlave = [
+            'write' => [],
+            'read'  => [],
+        ];
+
+        $masterSlave['write'] = [
+            'user'     => array_get($config, 'write.username', $config['username']),
+            'password' => array_get($config, 'write.password', $config['password']),
+            'host'     => array_get($config, 'write.host', $config['host']),
+            'dbname'   => array_get($config, 'write.database', $config['database']),
+            'port'     => array_get($config, 'write.port', $config['port']),
+        ];
+
+        foreach (array_get($config, 'read', []) as $slaveConfig) {
+            $config   = [
+                'user'     => array_get($slaveConfig, 'username', $config['username']),
+                'password' => array_get($slaveConfig, 'password', $config['password']),
+                'host'     => array_get($slaveConfig, 'host', $config['host']),
+                'dbname'   => array_get($slaveConfig, 'database', $config['database']),
+                'port'     => array_get($config, 'write.port', $config['port']),
+            ];
+
+            $masterSlave['read'][] = $config;
+        }
+
+        return $masterSlave;
+    }
+
+    /**
+     * @param array $config
+     *
+     * @return bool
+     */
+    public static function hasValidConfig(array $config)
+    {
+        if (
+            array_key_exists('read', $config)
+            && ! empty($config['read'])
+            && is_array($config['read'])
+            //All value in $config['read'] should be an array
+            && ! in_array(false, array_map(function ($readConfigValue) {
+                return is_array($readConfigValue);
+            }, $config['read']))
+            //All value in $config['read'] should have at least one config difference
+            && ! in_array(false, array_map(function (array $readConfig) {
+                return count($readConfig) > 0;
+            }, $config['read']))
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/tests/Utilities/ArrayUtilTest.php
+++ b/tests/Utilities/ArrayUtilTest.php
@@ -30,4 +30,35 @@ class ArrayUtilTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('default', ArrayUtil::get($values['key2'], 'default'));
     }
+
+    /**
+     * @dataProvider arrayProvider
+     *
+     * @param array $array1
+     * @param array $array2
+     * @param bool  $expectedEquals
+     */
+    public function test_hashArray_returns_unique_hash(array $array1, array $array2, $expectedEquals)
+    {
+        $hash1 = ArrayUtil::hashArray($array1);
+        $hash2 = ArrayUtil::hashArray($array2);
+
+        if ($expectedEquals) {
+            $this->assertEquals($hash1, $hash2);
+        } else {
+            $this->assertNotEquals($hash1, $hash2);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function arrayProvider()
+    {
+        return [
+            [[], [], true],
+            [['key1' => 'value1'], ['key1' => 'value1'], true],
+            [['key1' => 'value1'], ['key1' => 'value1-NOT-EQUALS'], false],
+        ];
+    }
 }

--- a/tests/Utilities/MasterSlaveConfigParserTest.php
+++ b/tests/Utilities/MasterSlaveConfigParserTest.php
@@ -1,0 +1,174 @@
+<?php
+
+use LaravelDoctrine\ORM\Utilities\MasterSlaveConfigParser;
+
+class MasterSlaveConfigParserTest extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @dataProvider validConfigProvider
+     *
+     * @param array $validConfig
+     */
+    public function test_HasValidConfig_returns_true_on_valid_config(array $validConfig)
+    {
+        $this->assertTrue(MasterSlaveConfigParser::hasValidConfig($validConfig));
+    }
+
+    /**
+     * @dataProvider invalidConfigProvider
+     *
+     * @param array $invalidConfig
+     */
+    public function test_HasValidConfig_returns_false_on_missing_config(array $invalidConfig)
+    {
+        $this->assertFalse(MasterSlaveConfigParser::hasValidConfig($invalidConfig));
+    }
+
+    /**
+     * @return array
+     */
+    public function validConfigProvider()
+    {
+        $valid1['config']        = array_merge(
+            $this->getDatabaseConfigTemplate(),
+            [
+                'write' => [
+                    'host' => '192.168.0.1',
+                ],
+                'read'  => [
+                    [
+                        'host'     => '192.168.0.2',
+                        'username' => 'read_user',
+                    ],
+                ],
+            ]
+        );
+        $valid1['expectedWrite'] = [
+            'user'     => 'write_db_username',
+            'password' => 'write_db_password',
+            'host'     => '192.168.0.1',  //Override the parent's localhost
+            'dbname'   => 'write_db_name',
+            'port'     => 3306,
+        ];
+        $valid1['expectedRead']  = [
+            [
+                'user'     => 'read_user',
+                'password' => 'write_db_password',
+                'host'     => '192.168.0.2',  //Override the parent's localhost
+                'dbname'   => 'write_db_name',
+                'port'     => 3306,
+            ],
+        ];
+
+        $valid2['config']        = array_merge(
+            $this->getDatabaseConfigTemplate(),
+            [
+                'read' => [
+                    [
+                        'host' => '192.168.0.1',
+                    ],
+                ]
+            ]
+        );
+        $valid2['expectedWrite'] = [
+            'user'     => 'write_db_username',
+            'password' => 'write_db_password',
+            'host'     => 'localhost',
+            'dbname'   => 'write_db_name',
+            'port'     => 3306,
+        ];
+        $valid2['expectedRead']  = [
+            [
+                'user'     => 'write_db_username',
+                'password' => 'write_db_password',
+                'host'     => '192.168.0.1',  //Override the parent's localhost
+                'dbname'   => 'write_db_name',
+                'port'     => 3306,
+            ],
+        ];
+
+        return [
+            [$valid1['config'], $valid1['expectedWrite'], $valid1['expectedRead']],
+            [$valid2['config'], $valid2['expectedWrite'], $valid2['expectedRead']],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getDatabaseConfigTemplate()
+    {
+        return [
+            'host'      => 'localhost',
+            'database'  => 'write_db_name',
+            'username'  => 'write_db_username',
+            'password'  => 'write_db_password',
+            'driver'    => 'mysql',
+            'port'      => 3306,
+            'charset'   => 'utf8',
+            'collation' => 'utf8_unicode_ci',
+            'prefix'    => '',
+            'strict'    => false,
+            'engine'    => null,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function invalidConfigProvider()
+    {
+        $invalidConfig1 = [];
+        $invalidConfig2 = array_merge(
+            $this->getDatabaseConfigTemplate(),
+            [
+                'write' => [],
+//                'read'  => [], //Read is missing, it's invalid
+            ]
+        );
+        $invalidConfig3 = array_merge(
+            $this->getDatabaseConfigTemplate(),
+            [
+                'write' => [],
+                'read'  => ['host' => '123'], //Read should be an array
+            ]
+        );
+
+        return [
+            [$invalidConfig1],
+            [$invalidConfig2],
+            [$invalidConfig3],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidConfigProvider
+     *
+     * @expectedException UnexpectedValueException
+     *
+     * @param array $invalidConfig
+     */
+    public function test_ParseConfig_throws_exception_on_invalid_config(array $invalidConfig)
+    {
+        MasterSlaveConfigParser::parseConfig($invalidConfig);
+    }
+
+    /**
+     * @dataProvider validConfigProvider
+     *
+     * @param array $config
+     * @param array $expectedWrite
+     * @param array $expectedRead
+     */
+    public function test_ParseConfig_can_inherit_settings(
+        array $config,
+        array $expectedWrite,
+        array $expectedRead
+    ) {
+        $readWriteConfig = MasterSlaveConfigParser::parseConfig($config);
+
+        $this->assertEquals($expectedRead, $readWriteConfig['read']);
+        $this->assertEquals($expectedWrite, $readWriteConfig['write']);
+    }
+}


### PR DESCRIPTION
### Changes proposed in this pull request:
- `EntityManagerFactory::create` avoid re-parse the config
- Can handle MasterSlaveConnection (http://www.doctrine-project.org/api/dbal/2.0/class-Doctrine.DBAL.Connections.MasterSlaveConnection.html)
## Important Notes

Since Laravel support only one slave (read-only) connection, not completely compatible with Laravel `database.php`

Differences:

**_Doctrine version:**_

``` php
            'read' => [
                [ //<==Please note, we need to add multiple arrays here!
                    'host' => env('DB_HOST_R', 'localhost'),
                    'database' => env('DB_DATABASE_R', ''),
                    'username' => env('DB_USERNAME_R', ''),
                    'password' => env('DB_PASSWORD_R', ''),
                ],
            ],
```

**_Laravel version:**_

``` php
            'read' => [
                    'host' => env('DB_HOST_R', 'localhost'),
                    'database' => env('DB_DATABASE_R', ''),
                    'username' => env('DB_USERNAME_R', ''),
                    'password' => env('DB_PASSWORD_R', ''),
            ],
```
