### PR TITLE
[FEATURE] Split service provider

### DIFF
--- a/src/DoctrineServiceProvider.php
+++ b/src/DoctrineServiceProvider.php
@@ -6,8 +6,6 @@ use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
-use Faker\Factory as FakerFactory;
-use Faker\Generator as FakerGenerator;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\ServiceProvider;
 use InvalidArgumentException;

--- a/src/DoctrineServiceProvider.php
+++ b/src/DoctrineServiceProvider.php
@@ -33,7 +33,6 @@ use LaravelDoctrine\ORM\Console\SchemaValidateCommand;
 use LaravelDoctrine\ORM\Exceptions\ExtensionNotFound;
 use LaravelDoctrine\ORM\Extensions\ExtensionManager;
 use LaravelDoctrine\ORM\Testing\Factory as EntityFactory;
-use LaravelDoctrine\ORM\Validation\PresenceVerifierProvider;
 
 class DoctrineServiceProvider extends ServiceProvider
 {
@@ -66,7 +65,6 @@ class DoctrineServiceProvider extends ServiceProvider
         $this->registerEntityManager();
         $this->registerClassMetaDataFactory();
         $this->registerExtensions();
-        $this->registerPresenceVerifierProvider();
         $this->registerConsoleCommands();
         $this->registerCustomTypes();
         $this->registerEntityFactory();
@@ -190,14 +188,6 @@ class DoctrineServiceProvider extends ServiceProvider
 
             return $manager;
         });
-    }
-
-    /**
-     * Register the deferred service provider for the validation presence verifier
-     */
-    protected function registerPresenceVerifierProvider()
-    {
-        $this->app->register(PresenceVerifierProvider::class);
     }
 
     /**

--- a/src/ValidationServiceProvider.php
+++ b/src/ValidationServiceProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace LaravelDoctrine\ORM;
+
+use Illuminate\Support\ServiceProvider;
+use LaravelDoctrine\ORM\Validation\PresenceVerifierProvider;
+
+class ValidationServiceProvider extends ServiceProvider
+{
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->registerPresenceVerifierProvider();
+    }
+
+
+    /**
+     * Register the deferred service provider for the validation presence verifier
+     */
+    protected function registerPresenceVerifierProvider()
+    {
+        $this->app->register(PresenceVerifierProvider::class);
+    }
+
+}


### PR DESCRIPTION
Move PresenceVerifierProvider to its own Service provider. This Service provider allows to register it independently to avoid override the native validation.presence service by default. 
