### PR TITLE
Fix the bug "Invalid PathExpression" in validation service

### DIFF
--- a/src/Validation/DoctrinePresenceVerifier.php
+++ b/src/Validation/DoctrinePresenceVerifier.php
@@ -92,7 +92,7 @@ class DoctrinePresenceVerifier implements PresenceVerifierInterface
         $em      = $this->getEntityManager($collection);
         $builder = $em->createQueryBuilder();
 
-        $builder->select('count(e)')->from($collection, 'e');
+        $builder->select('count(1)')->from($collection, 'e');
 
         return $builder;
     }


### PR DESCRIPTION
[FIX] "Invalid PathExpression" in validation service

Showed when the validation service was used with Doctrine version 2.5.4.
In the expression COUNT, was used the entity alias.
### Usage:

``` php
$this->validate($requrest, [
    'username' => 'unique:Model\Entity\User,username'
]);
```
