### PR TITLE
[FIX] Register proxy autoloader

### DIFF
--- a/src/DoctrineServiceProvider.php
+++ b/src/DoctrineServiceProvider.php
@@ -3,6 +3,7 @@
 namespace LaravelDoctrine\ORM;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Proxy\Autoloader;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
@@ -72,6 +73,7 @@ class DoctrineServiceProvider extends ServiceProvider
         $this->registerConsoleCommands();
         $this->registerCustomTypes();
         $this->registerEntityFactory();
+        $this->registerProxyAutoloader();
 
         if ($this->shouldRegisterDoctrinePresenceValidator()) {
             $this->registerPresenceVerifierProvider();
@@ -269,6 +271,24 @@ class DoctrineServiceProvider extends ServiceProvider
                 $app->make('registry'),
                 database_path('factories')
             );
+        });
+    }
+
+    /**
+     * Register proxy autoloader
+     *
+     * @return void
+     */
+    public function registerProxyAutoloader()
+    {
+        $this->app->afterResolving(ManagerRegistry::class, function (ManagerRegistry $registry) {
+            /** @var EntityManagerInterface $manager */
+            foreach ($registry->getManagers() as $manager) {
+                Autoloader::register(
+                    $manager->getConfiguration()->getProxyDir(),
+                    $manager->getConfiguration()->getProxyNamespace()
+                );
+            }
         });
     }
 


### PR DESCRIPTION
I just found that `laravel-doctrine` not registering proxy autoloader.
Problem that I got is that on unserializing doctrine entity in laravel queue for example, proxy classes not loaded/included so I got next exception on trying to `merge` unserialized entity:

```
Doctrine\ORM\Mapping\MappingException: Class "__PHP_Incomplete_Class" is not a valid entity or mapped super class. in vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/MappingException.php:346
```

P.S. Implementation not perfect but works for me.
P.S.S. Don't have time and idea how to test it.
