### PR TITLE
[FIX] Fix typehint mistake on getEntity method in DoctrineChannel + add toArray method to DoctrineChannel to match Laravel behaviour.

### DIFF
--- a/src/Notifications/DoctrineChannel.php
+++ b/src/Notifications/DoctrineChannel.php
@@ -57,10 +57,12 @@ class DoctrineChannel
             return $notification->toEntity($notifiable);
         } elseif (method_exists($notification, 'toDatabase')) {
             return $notification->toDatabase($notifiable);
+        } elseif (method_exists($notification, 'toArray')) {
+            return $notification->toArray($notifiable);
         }
 
         throw new RuntimeException(
-            'Notification is missing toDatabase / toEntity method.'
+            'Notification is missing toDatabase / toArray / toEntity method.'
         );
     }
 }

--- a/src/Notifications/DoctrineChannel.php
+++ b/src/Notifications/DoctrineChannel.php
@@ -57,12 +57,10 @@ class DoctrineChannel
             return $notification->toEntity($notifiable);
         } elseif (method_exists($notification, 'toDatabase')) {
             return $notification->toDatabase($notifiable);
-        } elseif (method_exists($notification, 'toArray')) {
-            return $notification->toArray($notifiable);
         }
 
         throw new RuntimeException(
-            'Notification is missing toDatabase / toArray / toEntity method.'
+            'Notification is missing toDatabase / toEntity method.'
         );
     }
 }

--- a/src/Notifications/DoctrineChannel.php
+++ b/src/Notifications/DoctrineChannel.php
@@ -47,7 +47,7 @@ class DoctrineChannel
     }
 
     /**
-     * @param  mixed        $notifiable
+     * @param  mixed               $notifiable
      * @param  LaravelNotification $notification
      * @return object
      */

--- a/src/Notifications/DoctrineChannel.php
+++ b/src/Notifications/DoctrineChannel.php
@@ -48,10 +48,10 @@ class DoctrineChannel
 
     /**
      * @param  mixed        $notifiable
-     * @param  Notification $notification
+     * @param  LaravelNotification $notification
      * @return object
      */
-    public function getEntity($notifiable, Notification $notification)
+    public function getEntity($notifiable, LaravelNotification $notification)
     {
         if (method_exists($notification, 'toEntity')) {
             return $notification->toEntity($notifiable);


### PR DESCRIPTION
Please prefix your pull request with one of the following: [FIX] [FEATURE].
### Changes proposed in this pull request:
- Typehint on getEntity method in DoctrineChannel was wrong. Was set to the LD Notification MappedSuperclass, but should have been the \Illuminate\Notifications\Notification class. You had aliased that to LaravelNotification.
- Added toArray check to match Laravel behaviour for database channel.
