### PR TITLE
[FEATURE] Different EntityManager class

### DIFF
--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -32,6 +32,7 @@ return [
                 base_path('app')
             ],
             'repository'    => Doctrine\ORM\EntityRepository::class,
+            'entity_manager'=> Doctrine\ORM\EntityManager::class,
             'proxies'       => [
                 'namespace'     => false,
                 'path'          => storage_path('proxies'),

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -120,7 +120,7 @@ class EntityManagerFactory
 
         $configuration->setEntityListenerResolver($this->resolver);
 
-        $manager = EntityManager::create(
+        $manager = array_get($settings, 'entity_manager', EntityManager::class)::create(
             $connection,
             $configuration
         );


### PR DESCRIPTION
# Configurable EM class

I came across this issue when I was trying to use extended EM class by [Kdyby](https://github.com/Kdyby/Doctrine). There is nothing much to say about it, I believe this wouldn't hurt anyone, but it opens up the possibility to extend standart doctrine classes a bit. 
### Changes proposed in this pull request:
- Instead of hard coded entity manager class use config value
- Added this value to config
