### PR TITLE
[Fix] Correcting a ConvertMapping CLI alias

### DIFF
--- a/src/Console/ConvertConfigCommand.php
+++ b/src/Console/ConvertConfigCommand.php
@@ -34,7 +34,7 @@ class ConvertConfigCommand extends SymfonyCommand
     protected function configure()
     {
         $this->setName('doctrine:config:convert')
-            ->setAliases(['doctrine:config:convert'])
+            ->setAliases(['doctrine:config:convert', 'doctrine:mapping:convert'])
             ->setDescription('Convert the configuration file for another laravel-doctrine implementation into a valid configuration for LaravelDoctrine\ORM')
             ->setDefinition([
                 new InputArgument('author', InputArgument::REQUIRED,


### PR DESCRIPTION

### Changes proposed in this pull request:

The doctrine command syntax for this is:
```
orm:convert-mapping Convert mapping information between supported formats.
```

This is for "converting mapping", whereas you've named this command "convert config" which isn't quite right.

Symfony has correctly named their CLI command: `doctrine:mapping:convert`

I've added an alias to keep your package inline with the rest of the eco-system.