### PR TITLE
[FIX] Missing state() function on Factory

### DIFF
--- a/src/Testing/Factory.php
+++ b/src/Testing/Factory.php
@@ -237,4 +237,13 @@ class Factory implements ArrayAccess
     {
         unset($this->definitions[$offset]);
     }
+
+	/**
+	 * Temporary fix to prevent Fatal on Laravel 5.3.17
+	 *
+	 * @return $this
+	 */
+	public function state() {
+		return $this;
+    }
 }

--- a/src/Testing/Factory.php
+++ b/src/Testing/Factory.php
@@ -238,12 +238,13 @@ class Factory implements ArrayAccess
         unset($this->definitions[$offset]);
     }
 
-	/**
-	 * Temporary fix to prevent Fatal on Laravel 5.3.17
-	 *
-	 * @return $this
-	 */
-	public function state() {
-		return $this;
+    /**
+     * Temporary fix to prevent Fatal on Laravel 5.3.17
+     *
+     * @return $this
+     */
+    public function state()
+    {
+        return $this;
     }
 }


### PR DESCRIPTION
With laravel/framework 5.3.17, they have added states to model factories. Since function state() is called on every factory() (and entity()) calls, testing with Doctrines Factory will fail on undefined function.

This PR only supresses the error, but does not implement states functionality. It's up to you, if it should be merged.
Ideally, Laravel-Doctrine might adopt states functionality, since it is same, as defineAs functionality. It would be just more familiar to Laravel users. States have one advantage compared to defineAs - you can stack states up.

What approach do you think would be best for Laravel-Doctrine?