### PR TITLE
[FEATURE] Add support for multiple cache implementations, separating result, query and metadata caching.

### DIFF
--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -155,9 +155,9 @@ return [
     |
     */
     'cache' => [
-        'second_level'  => false,
-        'default'       => 'array',
-        'namespace'     => null,
+        'second_level'     => false,
+        'default'          => 'array',
+        'namespace'        => null,
         'metadata'         => [
             'driver'       => env('DOCTRINE_METADATA_CACHE', 'array'),
             'namespace'    => null,

--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -154,10 +154,22 @@ return [
     | Available: apc|array|file|memcached|redis|void
     |
     */
-    'cache'                      => [
-        'default'      => env('DOCTRINE_CACHE', 'array'),
-        'namespace'    => null,
-        'second_level' => false,
+    'cache' => [
+        'second_level'  => false,
+        'default'       => 'array',
+        'namespace'     => null,
+        'metadata'         => [
+            'driver'       => env('DOCTRINE_METADATA_CACHE', 'array'),
+            'namespace'    => null,
+        ],
+        'query'            => [
+            'driver'       => env('DOCTRINE_QUERY_CACHE', 'array'),
+            'namespace'    => null,
+        ],
+        'result'           => [
+            'driver'       => env('DOCTRINE_RESULT_CACHE', 'array'),
+            'namespace'    => null,
+        ],
     ],
     /*
     |--------------------------------------------------------------------------

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -334,12 +334,12 @@ class EntityManagerFactory
 
     private function applyNamedCacheConfiguration($cacheName)
     {
-        $defaultDriver = $this->config->get('doctrine.cache.default', $this->defaultCache['type']);
+        $defaultDriver    = $this->config->get('doctrine.cache.default', $this->defaultCache['type']);
         $defaultNamespace = $this->config->get('doctrine.cache.namespace', $this->defaultCache['namespace']);
 
-        $driverType = $this->config->get('doctrine.cache.'.$cacheName.'.type', $defaultDriver);
+        $driverType = $this->config->get('doctrine.cache.' . $cacheName . '.type', $defaultDriver);
 
-        if ($namespace = $this->config->get('doctrine.cache.'.$cacheName.'.namespace', $defaultNamespace)) {
+        if ($namespace = $this->config->get('doctrine.cache.' . $cacheName . '.namespace', $defaultNamespace)) {
             $this->cache->driver($driverType)->setNamespace($namespace);
         }
 
@@ -362,7 +362,6 @@ class EntityManagerFactory
                 )
             );
         }
-
     }
 
     /**

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -93,9 +93,16 @@ class EntityManagerFactory
     {
         $configuration = $this->setup->createConfiguration(
             array_get($settings, 'dev', false),
-            array_get($settings, 'proxies.path'),
-            $this->cache->driver()
+            array_get($settings, 'proxies.path')
         );
+
+        $queryDriver = $this->cache->driver($this->config->get('doctrine.cache.query.type'));
+        $resultDriver = $this->cache->driver($this->config->get('doctrine.cache.result.type'));
+        $metaDriver = $this->cache->driver($this->config->get('doctrine.cache.metadata.type'));
+
+        $configuration->setQueryCacheImpl($queryDriver);
+        $configuration->setResultCacheImpl($resultDriver);
+        $configuration->setMetadataCacheImpl($metaDriver);
 
         $this->setMetadataDriver($settings, $configuration);
 
@@ -319,7 +326,8 @@ class EntityManagerFactory
     protected function setCacheSettings(Configuration $configuration)
     {
         if ($namespace = $this->config->get('doctrine.cache.namespace', null)) {
-            $this->cache->driver()->setNamespace($namespace);
+            $drv = $this->cache->driver();
+            $drv->setNamespace($namespace);
         }
 
         $this->setSecondLevelCaching($configuration);

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -334,8 +334,8 @@ class EntityManagerFactory
 
     private function applyNamedCacheConfiguration($cacheName)
     {
-        $defaultDriver = $this->config->get('doctrine.cache.default.type', $this->defaultCache['type']);
-        $defaultNamespace = $this->config->get('doctrine.cache.default.namespace', $this->defaultCache['namespace']);
+        $defaultDriver = $this->config->get('doctrine.cache.default', $this->defaultCache['type']);
+        $defaultNamespace = $this->config->get('doctrine.cache.namespace', $this->defaultCache['namespace']);
 
         $driverType = $this->config->get('doctrine.cache.'.$cacheName.'.type', $defaultDriver);
 

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -332,18 +332,22 @@ class EntityManagerFactory
         $this->setSecondLevelCaching($configuration);
     }
 
+    /**
+     * @param string $cacheName
+     * @return mixed
+     */
     private function applyNamedCacheConfiguration($cacheName)
     {
         $defaultDriver    = $this->config->get('doctrine.cache.default', $this->defaultCache['type']);
         $defaultNamespace = $this->config->get('doctrine.cache.namespace', $this->defaultCache['namespace']);
 
-        $driverType = $this->config->get('doctrine.cache.' . $cacheName . '.type', $defaultDriver);
+        $driver = $this->config->get('doctrine.cache.' . $cacheName . '.driver', $defaultDriver);
 
         if ($namespace = $this->config->get('doctrine.cache.' . $cacheName . '.namespace', $defaultNamespace)) {
-            $this->cache->driver($driverType)->setNamespace($namespace);
+            $this->cache->driver($driver)->setNamespace($namespace);
         }
 
-        return $this->cache->driver($driverType);
+        return $this->cache->driver($driver);
     }
 
     /**

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -333,7 +333,7 @@ class EntityManagerFactory
     }
 
     /**
-     * @param string $cacheName
+     * @param  string $cacheName
      * @return mixed
      */
     private function applyNamedCacheConfiguration($cacheName)

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -128,7 +128,6 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
             $this->config,
             $this->listenerResolver
         );
-
     }
 
     protected function assertEntityManager(EntityManagerInterface $manager)
@@ -648,7 +647,6 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
         $this->configuration->shouldReceive('setMetadataCacheImpl')->once();
         $this->configuration->shouldReceive('setQueryCacheImpl')->once();
         $this->configuration->shouldReceive('setResultCacheImpl')->once();
-
 
         $cache = m::mock(Cache::class);
         $this->configuration->shouldReceive('getMetadataCacheImpl')

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -247,7 +247,7 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
                      ->with('doctrine.cache.namespace', null)
                      ->andReturn('namespace');
 
-        foreach($this->caches as $cache) {
+        foreach ($this->caches as $cache) {
             $this->config->shouldReceive('get')
                          ->with('doctrine.cache.' . $cache . '.namespace', 'namespace')
                          ->once()
@@ -506,17 +506,16 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
         $this->config = m::mock(Repository::class);
 
         $this->config->shouldReceive('get')
-            ->with('doctrine.cache.default', 'array')
-            ->atLeast()->once()
-            ->andReturn('array');
+                     ->with('doctrine.cache.default', 'array')
+                     ->atLeast()->once()
+                     ->andReturn('array');
 
-        foreach($this->caches as $cache) {
+        foreach ($this->caches as $cache) {
             $this->config->shouldReceive('get')
                          ->with('doctrine.cache.' . $cache . '.type', 'array')
                          ->atLeast()->once()
                          ->andReturn('array');
         }
-
 
         $this->config->shouldReceive('has')
                      ->with('database.connections.mysql')
@@ -612,14 +611,12 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
                      ->atLeast()->once()
                      ->andReturn(null);
 
-        foreach($this->caches as $cache)
-        {
+        foreach ($this->caches as $cache) {
             $this->config->shouldReceive('get')
-                         ->with('doctrine.cache.'.$cache.'.namespace', null)
+                         ->with('doctrine.cache.' . $cache . '.namespace', null)
                          ->atLeast()->once()
                          ->andReturn(null);
         }
-
     }
 
     protected function disableCustomFunctions()

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -207,7 +207,7 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
                             ->atLeast()->once()->andReturn($cacheConfig);
 
         $this->cacheImpl = m::mock(Cache::class);
-        $this->cache->shouldReceive('driver')->once()->andReturn($this->cacheImpl);
+        $this->cache->shouldReceive('driver')->andReturn($this->cacheImpl);
 
         $this->configuration->shouldReceive('isSecondLevelCacheEnabled')
                             ->atLeast()->once()
@@ -226,11 +226,12 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
         $this->disableSecondLevelCaching();
 
         $this->config->shouldReceive('get')
-                     ->with('doctrine.cache.namespace', null)->once()
+                     ->with('doctrine.cache.namespace', null)
+                     ->once()
                      ->andReturn('namespace');
 
         $cache = m::mock(Cache::class);
-        $this->cache->shouldReceive('driver')->once()->andReturn($cache);
+        $this->cache->shouldReceive('driver')->andReturn($cache);
 
         $cache->shouldReceive('setNamespace')->once()->with('namespace');
 
@@ -477,6 +478,21 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
     {
         $this->config = m::mock(Repository::class);
 
+        $this->config->shouldReceive('get')
+                     ->with('doctrine.cache.query.type')
+                     ->once()
+                     ->andReturn('array');
+
+        $this->config->shouldReceive('get')
+                     ->with('doctrine.cache.metadata.type')
+                     ->once()
+                     ->andReturn('array');
+
+        $this->config->shouldReceive('get')
+                     ->with('doctrine.cache.result.type')
+                     ->once()
+                     ->andReturn('array');
+
         $this->config->shouldReceive('has')
                      ->with('database.connections.mysql')
                      ->once()
@@ -505,7 +521,7 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
     protected function mockCache()
     {
         $this->cache = m::mock(CacheManager::class);
-        $this->cache->shouldReceive('driver')->once()->andReturn(new ArrayCache());
+        $this->cache->shouldReceive('driver')->times(3)->andReturn(new ArrayCache());
     }
 
     protected function mockConnection()
@@ -594,6 +610,11 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
         $this->configuration->shouldReceive('getClassMetadataFactoryName')
                             ->atLeast()->once()
                             ->andReturn('Doctrine\ORM\Mapping\ClassMetadataFactory');
+
+        $this->configuration->shouldReceive('setMetadataCacheImpl')->once();
+        $this->configuration->shouldReceive('setQueryCacheImpl')->once();
+        $this->configuration->shouldReceive('setResultCacheImpl')->once();
+
 
         $cache = m::mock(Cache::class);
         $this->configuration->shouldReceive('getMetadataCacheImpl')

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -244,19 +244,18 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
         $this->disableSecondLevelCaching();
 
         $this->config->shouldReceive('get')
-            ->with('doctrine.cache.namespace', null)
-            ->andReturn('namespace');
+                     ->with('doctrine.cache.namespace', null)
+                     ->andReturn('namespace');
 
-        foreach($this->caches as $cache)
-        {
+        foreach($this->caches as $cache) {
             $this->config->shouldReceive('get')
-                         ->with('doctrine.cache.'.$cache.'.namespace', 'namespace')
+                         ->with('doctrine.cache.' . $cache . '.namespace', 'namespace')
                          ->once()
                          ->andReturn('namespace');
         }
 
-
         $cache = m::mock(Cache::class);
+
         $this->cache->shouldReceive('driver')
                     ->times($this->cachesCount)
                     ->andReturn($cache);
@@ -511,10 +510,9 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
             ->atLeast()->once()
             ->andReturn('array');
 
-        foreach($this->caches as $cache)
-        {
+        foreach($this->caches as $cache) {
             $this->config->shouldReceive('get')
-                         ->with('doctrine.cache.'.$cache.'.type', 'array')
+                         ->with('doctrine.cache.' . $cache . '.type', 'array')
                          ->atLeast()->once()
                          ->andReturn('array');
         }

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -244,7 +244,7 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
         $this->disableSecondLevelCaching();
 
         $this->config->shouldReceive('get')
-            ->with('doctrine.cache.default.namespace', null)
+            ->with('doctrine.cache.namespace', null)
             ->andReturn('namespace');
 
         foreach($this->caches as $cache)
@@ -506,7 +506,12 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
     {
         $this->config = m::mock(Repository::class);
 
-        foreach(array_merge($this->caches, ['default']) as $cache)
+        $this->config->shouldReceive('get')
+            ->with('doctrine.cache.default', 'array')
+            ->atLeast()->once()
+            ->andReturn('array');
+
+        foreach($this->caches as $cache)
         {
             $this->config->shouldReceive('get')
                          ->with('doctrine.cache.'.$cache.'.type', 'array')
@@ -604,7 +609,12 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
 
     protected function disableCustomCacheNamespace()
     {
-        foreach(array_merge($this->caches, ['default']) as $cache)
+        $this->config->shouldReceive('get')
+                     ->with('doctrine.cache.namespace', null)
+                     ->atLeast()->once()
+                     ->andReturn(null);
+
+        foreach($this->caches as $cache)
         {
             $this->config->shouldReceive('get')
                          ->with('doctrine.cache.'.$cache.'.namespace', null)

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -511,7 +511,7 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
 
         foreach ($this->caches as $cache) {
             $this->config->shouldReceive('get')
-                         ->with('doctrine.cache.' . $cache . '.type', 'array')
+                         ->with('doctrine.cache.' . $cache . '.driver', 'array')
                          ->atLeast()->once()
                          ->andReturn('array');
         }


### PR DESCRIPTION
This PR adds the ability to configure a different cache driver for each of metadata, result and query caching through the `doctrine.php` config file `'cache'` array.

### Changes proposed in this pull request:

The current cache array format is as follows:

```
'cache'            => [
    'default'      => env('DOCTRINE_CACHE', 'array'),
    'namespace'    => null,
    'second_level' => false,
]
```

This branch introduces this format:

  ```
    'cache' => [
        'second_level'     => false,
        'default'          => env('DOCTRINE_CACHE', 'array'),
        'namespace'        => null,
        'metadata'         => [
            'type'         => 'file',
            'namespace'    => null,
        ],
        'query'            => [
            'type'         => 'redis',
            'namespace'    => null,
        ],
        'result'           => [
            'type'         => 'array',
            'namespace'    => null,
        ],
    ],
```
The configuration is currently applied in this PR by calling `\Doctrine\ORM\Configuration->set[Result|Query|Metadata]CacheImpl` after reading the values from the config.

The `default` cache array entries remain the same to ensure backwards compatibility. If any of the metadata, result or query entries are missing from the configuration then they will take whichever the default entry is. The default entry is also mirrored/stored directly in code in case it's accidentally deleted from the configuration.
