### PR TITLE
[FEATURE] Add the routes substitute bindings middleware for doctrine entities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "illuminate/container": "5.2.*|5.3.*",
     "illuminate/contracts": "5.2.*|5.3.*",
     "illuminate/pagination": "5.2.*|5.3.*",
+    "illuminate/routing": "5.2.*|5.3.*",
     "illuminate/support": "5.2.*|5.3.*",
     "illuminate/validation": "5.2.*|5.3.*",
     "illuminate/view": "5.2.*|5.3.*",

--- a/src/Middleware/SubstituteBindings.php
+++ b/src/Middleware/SubstituteBindings.php
@@ -106,6 +106,6 @@ class SubstituteBindings
             return (new ReflectionMethod($class, $method))->getParameters();
         }
 
-        return $parameters = (new ReflectionFunction($uses))->getParameters();
+        return (new ReflectionFunction($uses))->getParameters();
     }
 }

--- a/src/Middleware/SubstituteBindings.php
+++ b/src/Middleware/SubstituteBindings.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace LaravelDoctrine\ORM\Middleware;
+
+use Closure;
+use LaravelDoctrine\ORM\IlluminateRegistry;
+use ReflectionMethod;
+use ReflectionFunction;
+use Doctrine\Common\Persistence\Proxy;
+use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Routing\Middleware\SubstituteBindings as IllumintateSubstituteBindings;
+
+class SubstituteBindings extends IllumintateSubstituteBindings
+{
+    /**
+     * @var IlluminateRegistry
+     */
+    protected $registry;
+
+    /**
+     * Create a new bindings substitutor.
+     *
+     * @param  Registrar          $router
+     * @param  IlluminateRegistry $registry
+     */
+    public function __construct(Registrar $router, IlluminateRegistry $registry)
+    {
+        parent::__construct($router);
+
+        $this->registry = $registry;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure                 $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $this->router->substituteBindings($route = $request->route());
+
+        $this->router->substituteImplicitBindings($route);
+
+        $this->substituteImplicitBindings($route);
+
+        return $next($request);
+    }
+
+    /**
+     * Substitute the implicit Doctrine entity bindings for the route.
+     *
+     * @param  \Illuminate\Routing\Route $route
+     * @return void
+     */
+    protected function substituteImplicitBindings($route)
+    {
+        $parameters = $route->parameters();
+
+        $action = $route->getAction();
+
+        foreach ($this->getParameters($action['uses']) as $parameter) {
+            $class = $parameter->getClass()->getName();
+
+            // Try to find the entity manager for the given class.
+            if (is_null($entityManager = $this->getDoctrineEntityManagerByClass($class))) {
+                continue;
+            }
+
+            if (array_key_exists($parameter->name, $parameters)) {
+                $entity = $entityManager->find($class, $parameters[$parameter->name]);
+
+                $route->setParameter($parameter->name, $entity);
+            }
+        }
+    }
+
+    /**
+     * Reflect the parameters of the method or function of the route.
+     *
+     * @param  string | Closure $uses
+     * @return \ReflectionParameter[]
+     */
+    protected function getParameters($uses)
+    {
+        if (is_string($uses)) {
+            list($class, $method) = explode('@', $uses);
+
+            return (new ReflectionMethod($class, $method))->getParameters();
+        }
+
+        return $parameters = (new ReflectionFunction($uses))->getParameters();
+    }
+
+    /**
+     * Try to fetch the entity manager of the given class.
+     *
+     * @param  string $class
+     * @return \Doctrine\Common\Persistence\ObjectManager | null
+     */
+    protected function getDoctrineEntityManagerByClass($class)
+    {
+        if (is_object($class)) {
+            $class = ($class instanceof Proxy) ? get_parent_class($class) : get_class($class);
+        }
+
+        return $this->registry->getManagerForClass($class);
+    }
+}

--- a/src/Middleware/SubstituteBindings.php
+++ b/src/Middleware/SubstituteBindings.php
@@ -3,10 +3,10 @@
 namespace LaravelDoctrine\ORM\Middleware;
 
 use Closure;
+use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityNotFoundException;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Routing\Route;
-use LaravelDoctrine\ORM\IlluminateRegistry;
 use ReflectionFunction;
 use ReflectionMethod;
 
@@ -15,22 +15,22 @@ class SubstituteBindings
     /**
      * The router instance.
      *
-     * @var \Illuminate\Contracts\Routing\Registrar
+     * @var Registrar
      */
     protected $router;
 
     /**
-     * @var IlluminateRegistry
+     * @var ManagerRegistry
      */
     protected $registry;
 
     /**
      * Create a new bindings substitutor.
      *
-     * @param Registrar          $router
-     * @param IlluminateRegistry $registry
+     * @param Registrar       $router
+     * @param ManagerRegistry $registry
      */
-    public function __construct(Registrar $router, IlluminateRegistry $registry)
+    public function __construct(Registrar $router, ManagerRegistry $registry)
     {
         $this->router   = $router;
         $this->registry = $registry;

--- a/src/Middleware/SubstituteBindings.php
+++ b/src/Middleware/SubstituteBindings.php
@@ -7,8 +7,8 @@ use Doctrine\Common\Persistence\Proxy;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Routing\Middleware\SubstituteBindings as IllumintateSubstituteBindings;
 use LaravelDoctrine\ORM\IlluminateRegistry;
-use ReflectionMethod;
 use ReflectionFunction;
+use ReflectionMethod;
 
 class SubstituteBindings extends IllumintateSubstituteBindings
 {

--- a/src/Middleware/SubstituteBindings.php
+++ b/src/Middleware/SubstituteBindings.php
@@ -32,7 +32,7 @@ class SubstituteBindings
      */
     public function __construct(Registrar $router, IlluminateRegistry $registry)
     {
-        $this->router = $router;
+        $this->router   = $router;
         $this->registry = $registry;
     }
 

--- a/src/Middleware/SubstituteBindings.php
+++ b/src/Middleware/SubstituteBindings.php
@@ -45,7 +45,9 @@ class SubstituteBindings
      */
     public function handle($request, Closure $next)
     {
-        $this->substituteImplicitBindings($request->route());
+        $this->router->substituteBindings($route = $request->route());
+
+        $this->substituteImplicitBindings($route);
 
         return $next($request);
     }

--- a/src/Middleware/SubstituteBindings.php
+++ b/src/Middleware/SubstituteBindings.php
@@ -81,7 +81,7 @@ class SubstituteBindings
             // Find the entity by route parameter value.
             $entity = $entityManager->find($class, $parameters[$parameter->name]);
 
-            // When no entity is found check if the route excepts an empty entity.
+            // When no entity is found check if the route accepts an empty entity.
             if (is_null($entity) && ! $parameter->isDefaultValueAvailable()) {
                 throw new EntityNotFoundException(sprintf('No query results for entity [%s]', $class));
             }

--- a/src/Middleware/SubstituteBindings.php
+++ b/src/Middleware/SubstituteBindings.php
@@ -3,12 +3,12 @@
 namespace LaravelDoctrine\ORM\Middleware;
 
 use Closure;
-use LaravelDoctrine\ORM\IlluminateRegistry;
-use ReflectionMethod;
-use ReflectionFunction;
 use Doctrine\Common\Persistence\Proxy;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Routing\Middleware\SubstituteBindings as IllumintateSubstituteBindings;
+use LaravelDoctrine\ORM\IlluminateRegistry;
+use ReflectionMethod;
+use ReflectionFunction;
 
 class SubstituteBindings extends IllumintateSubstituteBindings
 {
@@ -20,8 +20,8 @@ class SubstituteBindings extends IllumintateSubstituteBindings
     /**
      * Create a new bindings substitutor.
      *
-     * @param  Registrar          $router
-     * @param  IlluminateRegistry $registry
+     * @param Registrar          $router
+     * @param IlluminateRegistry $registry
      */
     public function __construct(Registrar $router, IlluminateRegistry $registry)
     {
@@ -79,7 +79,7 @@ class SubstituteBindings extends IllumintateSubstituteBindings
     /**
      * Reflect the parameters of the method or function of the route.
      *
-     * @param  string | Closure $uses
+     * @param  string | Closure       $uses
      * @return \ReflectionParameter[]
      */
     protected function getParameters($uses)
@@ -96,7 +96,7 @@ class SubstituteBindings extends IllumintateSubstituteBindings
     /**
      * Try to fetch the entity manager of the given class.
      *
-     * @param  string $class
+     * @param  string                                     $class
      * @return \Doctrine\Common\Persistence\ObjectManager | null
      */
     protected function getDoctrineEntityManagerByClass($class)

--- a/tests/Middleware/SubstituteBindingsTest.php
+++ b/tests/Middleware/SubstituteBindingsTest.php
@@ -1,0 +1,168 @@
+<?php
+
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\EntityManager;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Router;
+use LaravelDoctrine\ORM\Middleware\SubstituteBindings;
+use Mockery\Mock;
+
+class SubstituteBindingsTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Mock
+     */
+    private $registry;
+
+    /**
+     * @var Mock
+     */
+    private $em;
+
+    public function setUp()
+    {
+        $this->registry = Mockery::mock(ManagerRegistry::class);
+        $this->em       = Mockery::mock(EntityManager::class);
+    }
+
+    protected function getRouter()
+    {
+        $container = new Container;
+        $router    = new Router(new Dispatcher, $container);
+        $container->singleton(Registrar::class, function () use ($router) {
+            return $router;
+        });
+
+        $container->singleton(ManagerRegistry::class, function () {
+            return $this->registry;
+        });
+
+        return $router;
+    }
+
+    protected function mockRegistry()
+    {
+        $this->registry->shouldReceive('getManagerForClass')->once()->with('BindableEntity')->andReturn($this->em);
+    }
+
+    public function test_entity_binding()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/{entity}', [
+            'middleware' => SubstituteBindings::class,
+            'uses'       => function (BindableEntity $entity) {
+                return $entity->getName();
+            },
+        ]);
+
+        $this->mockRegistry();
+        $entity       = new BindableEntity();
+        $entity->id   = 1;
+        $entity->name = 'NAMEVALUE';
+        $this->em->shouldReceive('find')->once()->with('BindableEntity', 1)->andReturn($entity);
+
+        $this->assertEquals('namevalue', $router->dispatch(Request::create('foo/1', 'GET'))->getContent());
+    }
+
+    public function test_entity_binding_expect_entity_not_found_exception()
+    {
+        $this->setExpectedException('Doctrine\ORM\EntityNotFoundException');
+
+        $router = $this->getRouter();
+
+        $router->get('foo/{entity}', [
+            'middleware' => SubstituteBindings::class,
+            'uses'       => function (BindableEntity $entity) {
+                return $entity->getName();
+            },
+        ]);
+
+        $this->mockRegistry();
+        $this->em->shouldReceive('find')->once()->with('BindableEntity', 1)->andReturn(null);
+
+        $router->dispatch(Request::create('foo/1', 'GET'))->getContent();
+    }
+
+    public function test_entity_binding_get_null_entity()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/{entity}', [
+            'middleware' => SubstituteBindings::class,
+            'uses'       => function (BindableEntity $entity = null) {
+                return $entity->getName();
+            },
+        ]);
+
+        $this->mockRegistry();
+        $this->em->shouldReceive('find')->once()->with('BindableEntity', 1)->andReturn(null);
+
+        $this->assertEquals('', $router->dispatch(Request::create('foo/1', 'GET'))->getContent());
+    }
+
+    public function test_binding_value()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/{value}', [
+            'middleware' => SubstituteBindings::class,
+            'uses'       => function ($value) {
+                return $value;
+            },
+        ]);
+
+        $this->assertEquals(123456, $router->dispatch(Request::create('foo/123456', 'GET'))->getContent());
+
+        $router->get('doc/trine', [
+            'middleware' => SubstituteBindings::class,
+            'uses'       => function (Request $request) {
+                return $request instanceof Request ? 'request' : 'something else';
+            },
+        ]);
+
+        $this->assertEquals('request', $router->dispatch(Request::create('doc/trine', 'GET'))->getContent());
+    }
+
+    public function test_controller_entity_binding()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/{entity}', [
+            'uses'       => 'EntityController@index',
+            'middleware' => SubstituteBindings::class,
+        ]);
+
+        $this->mockRegistry();
+        $entity       = new BindableEntity();
+        $entity->id   = 1;
+        $entity->name = 'NAMEVALUE';
+        $this->em->shouldReceive('find')->once()->with('BindableEntity', 1)->andReturn($entity);
+
+        $this->assertEquals('namevalue', $router->dispatch(Request::create('foo/1', 'GET'))->getContent());
+    }
+}
+
+class BindableEntity
+{
+    public $id;
+
+    public $name;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return strtolower($this->name);
+    }
+}
+
+class EntityController
+{
+    public function index(BindableEntity $entity)
+    {
+        return $entity->getName();
+    }
+}

--- a/tests/Middleware/SubstituteBindingsTest.php
+++ b/tests/Middleware/SubstituteBindingsTest.php
@@ -8,6 +8,7 @@ use Illuminate\Events\Dispatcher;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use LaravelDoctrine\ORM\Middleware\SubstituteBindings;
+use Mockery as m;
 use Mockery\Mock;
 
 class SubstituteBindingsTest extends PHPUnit_Framework_TestCase
@@ -24,8 +25,8 @@ class SubstituteBindingsTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->registry = Mockery::mock(ManagerRegistry::class);
-        $this->em       = Mockery::mock(EntityManager::class);
+        $this->registry = m::mock(ManagerRegistry::class);
+        $this->em       = m::mock(EntityManager::class);
     }
 
     protected function getRouter()
@@ -139,6 +140,11 @@ class SubstituteBindingsTest extends PHPUnit_Framework_TestCase
         $this->em->shouldReceive('find')->once()->with('BindableEntity', 1)->andReturn($entity);
 
         $this->assertEquals('namevalue', $router->dispatch(Request::create('foo/1', 'GET'))->getContent());
+    }
+
+    protected function tearDown()
+    {
+        m::close();
     }
 }
 


### PR DESCRIPTION
#187 

I've added the SubstituteBindings middleware which replaces the laravel middleware.
The entity manager will be fetched from the registry class.

I will try to add tests asap!

### Changes proposed in this pull request:
- Added SubstituteBindings middleware.
- Added Illuminate/routing 5.2.*|5.4.* to composer.json