### PR TITLE
[FIX] Add Laravel 5.4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Version | Supported Laravel Versions | Support
 :---------|:----------|:----------
 1.0.x |  5.1.x | Bugfix and security releases
 1.1.x | 5.2.x |  Bugfix and security releases
-1.2.x | 5.2.x, 5.3.x | New features
+1.2.x | 5.2.x, 5.3.x, 5.4.x | New features
 
 Require this package  
 

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
   "require": {
     "php": ">=5.5.9",
     "doctrine/orm": "2.5.*",
-    "illuminate/auth": "5.2.*|5.3.*",
-    "illuminate/console": "5.2.*|5.3.*",
-    "illuminate/container": "5.2.*|5.3.*",
-    "illuminate/contracts": "5.2.*|5.3.*",
-    "illuminate/pagination": "5.2.*|5.3.*",
-    "illuminate/support": "5.2.*|5.3.*",
-    "illuminate/validation": "5.2.*|5.3.*",
-    "illuminate/view": "5.2.*|5.3.*",
+    "illuminate/auth": "5.2.*|5.3.*|5.4.*",
+    "illuminate/console": "5.2.*|5.3.*|5.4.*",
+    "illuminate/container": "5.2.*|5.3.*|5.4.*",
+    "illuminate/contracts": "5.2.*|5.3.*|5.4.*",
+    "illuminate/pagination": "5.2.*|5.3.*|5.4.*",
+    "illuminate/support": "5.2.*|5.3.*|5.4.*",
+    "illuminate/validation": "5.2.*|5.3.*|5.4.*",
+    "illuminate/view": "5.2.*|5.3.*|5.4.*",
     "symfony/serializer": "^2.7"
   },
   "require-dev": {
@@ -33,9 +33,9 @@
     "mockery/mockery": "~0.9",
     "barryvdh/laravel-debugbar": "~2.0",
     "itsgoingd/clockwork": "~1.9",
-    "illuminate/log": "5.2.*|5.3.*",
-    "illuminate/notifications": "5.3.*",
-    "illuminate/queue": "5.3.*"
+    "illuminate/log": "5.2.*|5.3.*|5.4.*",
+    "illuminate/notifications": "5.3.*|5.4.*",
+    "illuminate/queue": "5.3.*|5.4.*"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
### Changes proposed in this pull request:

- Adds Laravel 5.4 support

This really doesn't breaks anything as far as I can tell. Or the tests are letting it pass :)
So I'm considering this a minor feature and sending it to the 1.2 branch.