### PR TITLE
[FIX] Fixing default caching bug introduced from #205

### DIFF
--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -2,6 +2,7 @@
 
 namespace LaravelDoctrine\ORM;
 
+use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\Cache;
 use Doctrine\ORM\Cache\DefaultCacheFactory;
 use Doctrine\ORM\Configuration;
@@ -92,9 +93,12 @@ class EntityManagerFactory
      */
     public function create(array $settings = [])
     {
+        $defaultDriver = $this->config->get('doctrine.cache.default', 'array');
+
         $configuration = $this->setup->createConfiguration(
             array_get($settings, 'dev', false),
-            array_get($settings, 'proxies.path')
+            array_get($settings, 'proxies.path'),
+            $this->cache->driver($defaultDriver)
         );
 
         $this->setMetadataDriver($settings, $configuration);


### PR DESCRIPTION
### Changes proposed in this pull request:
- Added default cache parameter in createConfiguration

If you have memcached or redis extensions installed
doctrine will try to automatically connect to one of them
if no cache paramter is set when dev mode is off. Defaulting
to ArrayCache to prevent that behavior from occuring.

Signed-off-by: RJ Garcia <rj@bighead.net>