### PR TITLE
[FEATURE] Master/slave connection support.

### DIFF
--- a/src/Configuration/Connections/MasterSlaveConnection.php
+++ b/src/Configuration/Connections/MasterSlaveConnection.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace LaravelDoctrine\ORM\Configuration\Connections;
+
+use Doctrine\DBAL\Connections\MasterSlaveConnection as MasterSlaveDoctrineWrapper;
+use Illuminate\Contracts\Config\Repository;
+
+/**
+ * Handles master slave connection settings.
+ */
+class MasterSlaveConnection extends Connection
+{
+    /**
+     * @var array|Connection
+     */
+    private $resolvedBaseSettings;
+
+    /**
+     * @var array Ignored configuration fields for master slave configuration.
+     */
+    private $masterSlaveConfigIgnored = ['driver'];
+
+    /**
+     * MasterSlaveConnection constructor.
+     *
+     * @param Repository       $config
+     * @param array|Connection $resolvedBaseSettings
+     */
+    public function __construct(Repository $config, $resolvedBaseSettings)
+    {
+        parent::__construct($config);
+
+        $this->resolvedBaseSettings = $resolvedBaseSettings;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve(array $settings = [])
+    {
+        $driver = $this->resolvedBaseSettings['driver'];
+
+        return [
+            'wrapperClass' => MasterSlaveDoctrineWrapper::class,
+            'driver'       => $driver,
+            'master'       => $this->getConnectionData(isset($settings['write']) ? $settings['write'] : [], $driver),
+            'slaves'       => $this->getSlavesConfig($settings['read'], $driver),
+        ];
+    }
+
+    /**
+     * Returns config for slave connections.
+     *
+     * @param array  $slaves
+     * @param string $driver
+     *
+     * @return array
+     */
+    public function getSlavesConfig(array $slaves, $driver)
+    {
+        $handledSlaves = [];
+        foreach ($slaves as $slave) {
+            $handledSlaves[] = $this->getConnectionData($slave, $driver);
+        }
+
+        return $handledSlaves;
+    }
+
+    /**
+     * Returns single connection (slave or master) config.
+     *
+     * @param array  $connection
+     * @param string $driver
+     *
+     * @return array
+     */
+    private function getConnectionData(array $connection, $driver)
+    {
+        $connection = $this->replaceKeyIfExists($connection, 'database', $driver === 'pdo_sqlite' ? 'path' : 'dbname');
+        $connection = $this->replaceKeyIfExists($connection, 'username', 'user');
+
+        return array_merge($this->getFilteredConfig(), $connection);
+    }
+
+    /**
+     * Returns filtered configuration to use in slaves/masters.
+     *
+     * @return array
+     */
+    private function getFilteredConfig()
+    {
+        return array_diff_key($this->resolvedBaseSettings, array_flip($this->masterSlaveConfigIgnored));
+    }
+
+    /**
+     * Replaces key in array if it exists.
+     *
+     * @param array  $array
+     * @param string $oldKey
+     * @param string $newKey
+     *
+     * @return array
+     */
+    private function replaceKeyIfExists(array $array, $oldKey, $newKey)
+    {
+        if (!isset($array[$oldKey])) {
+            return $array;
+        }
+
+        $array[$newKey] = $array[$oldKey];
+        unset($array[$oldKey]);
+
+        return $array;
+    }
+}

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -479,7 +479,7 @@ class EntityManagerFactory
             throw new \InvalidArgumentException("Parameter 'read' must be an array containing multiple arrays.");
         }
 
-        if (($key = array_search(0, array_map('count', $slaves))) && $key !== false) {
+        if (($key = array_search(0, array_map('count', $slaves))) !== false) {
             throw new \InvalidArgumentException("Parameter 'read' config no. {$key} is empty.");
         }
 

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -110,7 +110,8 @@ class EntityManagerFactory
             $driver
         );
 
-        if ($this->isMasterSlaveConfigured($driver) && $this->hasValidMasterSlaveConfig($driver)) {
+        if ($this->isMasterSlaveConfigured($driver)) {
+            $this->hasValidMasterSlaveConfig($driver);
             $connection = (new MasterSlaveConnection($this->config, $connection))->resolve($driver);
         }
 
@@ -464,8 +465,6 @@ class EntityManagerFactory
      * Check if slave configuration is valid.
      *
      * @param array $driverConfig
-     *
-     * @return bool
      */
     private function hasValidMasterSlaveConfig(array $driverConfig)
     {
@@ -482,7 +481,5 @@ class EntityManagerFactory
         if (($key = array_search(0, array_map('count', $slaves))) !== false) {
             throw new \InvalidArgumentException("Parameter 'read' config no. {$key} is empty.");
         }
-
-        return true;
     }
 }

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;
 use LaravelDoctrine\ORM\Configuration\Cache\CacheManager;
 use LaravelDoctrine\ORM\Configuration\Connections\ConnectionManager;
+use LaravelDoctrine\ORM\Configuration\Connections\MasterSlaveConnection;
 use LaravelDoctrine\ORM\Configuration\LaravelNamingStrategy;
 use LaravelDoctrine\ORM\Configuration\MetaData\MetaData;
 use LaravelDoctrine\ORM\Configuration\MetaData\MetaDataManager;
@@ -108,6 +109,10 @@ class EntityManagerFactory
             $driver['driver'],
             $driver
         );
+
+        if ($this->isMasterSlaveConfigured($driver) && $this->hasValidMasterSlaveConfig($driver)) {
+            $connection = (new MasterSlaveConnection($this->config, $connection))->resolve($driver);
+        }
 
         $this->setNamingStrategy($settings, $configuration);
         $this->setCustomFunctions($configuration);
@@ -439,5 +444,45 @@ class EntityManagerFactory
             // Throw DBALException if Doctrine Type is not found.
             $manager->getConnection()->getDatabasePlatform()->registerDoctrineTypeMapping($dbType, $doctrineType);
         }
+    }
+
+    /**
+     * Check if master slave connection was being configured.
+     *
+     * @param array $driverConfig
+     *
+     * @return bool
+     */
+    private function isMasterSlaveConfigured(array $driverConfig)
+    {
+        // Setting read is mandatory for master/slave configuration. Setting write is optional.
+        // But if write was set and read wasn't, it means configuration is incorrect and we must inform the user.
+        return isset($driverConfig['read']) || isset($driverConfig['write']);
+    }
+
+    /**
+     * Check if slave configuration is valid.
+     *
+     * @param array $driverConfig
+     *
+     * @return bool
+     */
+    private function hasValidMasterSlaveConfig(array $driverConfig)
+    {
+        if (!isset($driverConfig['read'])) {
+            throw new \InvalidArgumentException("Parameter 'read' must be set for read/write config.");
+        }
+
+        $slaves = $driverConfig['read'];
+
+        if (!is_array($slaves) || in_array(false, array_map('is_array', $slaves))) {
+            throw new \InvalidArgumentException("Parameter 'read' must be an array containing multiple arrays.");
+        }
+
+        if (($key = array_search(0, array_map('count', $slaves))) && $key !== false) {
+            throw new \InvalidArgumentException("Parameter 'read' config no. {$key} is empty.");
+        }
+
+        return true;
     }
 }

--- a/tests/Configuration/Connections/MasterSlaveConnectionTest.php
+++ b/tests/Configuration/Connections/MasterSlaveConnectionTest.php
@@ -1,0 +1,259 @@
+<?php
+
+use Doctrine\DBAL\Connections\MasterSlaveConnection as MasterSlaveDoctrineWrapper;
+use Illuminate\Contracts\Config\Repository;
+use LaravelDoctrine\ORM\Configuration\Connections\MasterSlaveConnection;
+use Mockery as m;
+
+/**
+ * Basic unit tests for master slave connection.
+ */
+class MasterSlaveConnectionTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Data provider for testMasterSlaveConnection.
+     *
+     * @return array
+     */
+    public function getMasterSlaveConnectionData()
+    {
+        $out = [];
+
+        $dummyInputConfig = [
+            'driver'    => 'mysql',
+            'host'      => 'localhost',
+            'port'      => '3306',
+            'database'  => 'test',
+            'username'  => 'homestead',
+            'password'  => 'secret',
+            'charset'   => 'utf8',
+            'collation' => 'utf8_unicode_ci',
+            'prefix'    => '',
+            'strict'    => false,
+            'engine'    => null,
+            'write'     => [
+                'port'      => 3307,
+                'user'      => 'homestead1',
+                'password'  => 'secret1',
+            ],
+            'read' => [
+                [
+                    'port'     => 3308,
+                    'database' => 'test2',
+                ],
+                [
+                    'host' => 'localhost2',
+                    'port' => 3309
+                ],
+            ],
+        ];
+
+        $dummyExpectedConfig = [
+            'wrapperClass' => MasterSlaveDoctrineWrapper::class,
+            'driver'       => 'pdo_mysql',
+            'slaves'       => [
+                [
+                    'host'        => 'localhost',
+                    'user'        => 'homestead',
+                    'password'    => 'secret',
+                    'dbname'      => 'test2',
+                    'port'        => '3308',
+                    'charset'     => 'charset',
+                    'unix_socket' => 'unix_socket',
+                    'prefix'      => 'prefix'
+                ],
+                [
+                    'host'        => 'localhost2',
+                    'user'        => 'homestead',
+                    'password'    => 'secret',
+                    'dbname'      => 'test',
+                    'port'        => '3309',
+                    'charset'     => 'charset',
+                    'unix_socket' => 'unix_socket',
+                    'prefix'      => 'prefix'
+                ]
+            ],
+            'master' => [
+                'host'        => 'localhost',
+                'user'        => 'homestead1',
+                'password'    => 'secret1',
+                'dbname'      => 'test',
+                'port'        => '3307',
+                'charset'     => 'charset',
+                'unix_socket' => 'unix_socket',
+                'prefix'      => 'prefix'
+            ],
+        ];
+
+        // Case #0. Simple valid configuration with mysql base settings.
+        $resolvedBaseSettings = [
+            'driver'      => 'pdo_mysql',
+            'host'        => 'localhost',
+            'dbname'      => 'test',
+            'user'        => 'homestead',
+            'password'    => 'secret',
+            'charset'     => 'charset',
+            'port'        => 'port',
+            'unix_socket' => 'unix_socket',
+            'prefix'      => 'prefix'
+        ];
+        $out[] = [$resolvedBaseSettings, $dummyInputConfig, $dummyExpectedConfig];
+
+        // Case #1. Configuration is only set in the read/wriet nodes.
+        $resolvedBaseSettings = [
+            'driver'      => 'pdo_mysql',
+        ];
+
+        $expectedConfig = [
+            'wrapperClass' => MasterSlaveDoctrineWrapper::class,
+            'driver'       => 'pdo_mysql',
+            'slaves'       => [
+                [
+                    'host'     => 'localhost',
+                    'user'     => 'homestead',
+                    'password' => 'secret',
+                    'dbname'   => 'test2',
+                    'port'     => '3308',
+                ],
+                [
+                    'host'     => 'localhost2',
+                    'user'     => 'homestead',
+                    'password' => 'secret',
+                    'dbname'   => 'test',
+                    'port'     => '3309',
+                ]
+            ],
+            'master' => [
+                'host'     => 'localhost',
+                'user'     => 'homestead',
+                'password' => 'secret1',
+                'dbname'   => 'test',
+                'port'     => '3307',
+            ],
+        ];
+
+        $inputConfig = [
+            'write' => [
+                'port'     => 3307,
+                'password' => 'secret1',
+                'host'     => 'localhost',
+                'database' => 'test',
+                'username' => 'homestead'
+            ],
+            'read' => [
+                [
+                    'port'     => 3308,
+                    'database' => 'test2',
+                    'host'     => 'localhost',
+                    'username' => 'homestead',
+                    'password' => 'secret'
+                ],
+                [
+                    'host'     => 'localhost2',
+                    'port'     => 3309,
+                    'database' => 'test',
+                    'username' => 'homestead',
+                    'password' => 'secret'
+                ],
+            ],
+        ];
+        $out[] = [$resolvedBaseSettings, $inputConfig, $expectedConfig];
+
+        // Case #2. Simple valid configuration with oracle base settings.
+        $expectedConfigOracle                   = $expectedConfig;
+        $expectedConfigOracle['driver']         = 'oci8';
+        $expectedConfigOracle['master']['user'] = 'homestead1';
+
+        $resolvedBaseSettings = [
+            'driver'      => 'oci8',
+            'host'        => 'localhost',
+            'dbname'      => 'test',
+            'user'        => 'homestead',
+            'password'    => 'secret',
+            'port'        => 'port',
+        ];
+        $out[] = [$resolvedBaseSettings, $dummyInputConfig, $expectedConfigOracle];
+
+        // Case #3. Simple valid configuration with pgqsql base settings.
+        $expectedConfigPgsql                         = $expectedConfig;
+        $expectedConfigPgsql['driver']               = 'pgsql';
+        $expectedConfigPgsql['master']['user']       = 'homestead1';
+        $expectedConfigPgsql['master']['sslmode']    = 'sslmode';
+        $expectedConfigPgsql['slaves'][0]['sslmode'] = 'sslmode';
+        $expectedConfigPgsql['slaves'][1]['sslmode'] = 'sslmode';
+
+        $resolvedBaseSettings = [
+            'driver'      => 'pgsql',
+            'host'        => 'localhost',
+            'dbname'      => 'test',
+            'user'        => 'homestead',
+            'password'    => 'secret',
+            'port'        => 'port',
+            'sslmode'     => 'sslmode',
+        ];
+        $out[] = [$resolvedBaseSettings, $dummyInputConfig, $expectedConfigPgsql];
+
+        // Case #4. Simple valid configuration with sqlite base settings.
+        $inputConfigSqlite = $dummyInputConfig;
+        unset($inputConfigSqlite['read'][0]['database']);
+        unset($inputConfigSqlite['read'][1]['database']);
+        unset($inputConfigSqlite['write']['database']);
+
+        $expectedConfigSqlite = [
+            'wrapperClass' => MasterSlaveDoctrineWrapper::class,
+            'driver'       => 'pdo_sqlite',
+            'slaves'       => [
+                [
+                    'user'     => 'homestead',
+                    'password' => 'secret',
+                    'port'     => 3308,
+                    'path'     => ':memory',
+                    'memory'   => true,
+                ],
+                [
+                    'host'     => 'localhost2',
+                    'user'     => 'homestead',
+                    'password' => 'secret',
+                    'port'     => 3309,
+                    'path'     => ':memory',
+                    'memory'   => true,
+                ]
+            ],
+            'master' => [
+                'user'     => 'homestead1',
+                'password' => 'secret1',
+                'port'     => 3307,
+                'memory'   => true,
+                'path'     => ':memory',
+            ],
+        ];
+
+        $resolvedBaseSettings = [
+            'driver'   => 'pdo_sqlite',
+            'path'     => ':memory',
+            'user'     => 'homestead',
+            'password' => 'secret',
+            'memory'   => true
+        ];
+        $out[] = [$resolvedBaseSettings, $inputConfigSqlite, $expectedConfigSqlite];
+
+        return $out;
+    }
+
+    /**
+     * Check if master slave connection manages configuration well.
+     *
+     * @param array $resolvedBaseSettings
+     * @param array $settings
+     * @param $expectedOutput
+     *
+     * @dataProvider getMasterSlaveConnectionData
+     */
+    public function testMasterSlaveConnection(array $resolvedBaseSettings, array $settings, array $expectedOutput)
+    {
+        $this->assertEquals(
+            $expectedOutput,
+            (new MasterSlaveConnection(m::mock(Repository::class), $resolvedBaseSettings))->resolve($settings)
+        );
+    }
+}

--- a/tests/Configuration/Connections/MasterSlaveConnectionTest.php
+++ b/tests/Configuration/Connections/MasterSlaveConnectionTest.php
@@ -19,7 +19,49 @@ class MasterSlaveConnectionTest extends PHPUnit_Framework_TestCase
     {
         $out = [];
 
-        $dummyInputConfig = [
+        // Case #0. Simple valid configuration with mysql base settings.
+        $out[] = [$this->getResolvedMysqlConfig(), $this->getInputConfig(), $this->getExpectedConfig()];
+
+        // Case #1. Configuration is only set in the read/write nodes.
+        $out[] = [['driver' => 'pdo_mysql'], $this->getNodesInputConfig(), $this->getNodesExpectedConfig()];
+
+        // Case #2. Simple valid configuration with oracle base settings.
+        $out[] = [$this->getResolvedOracleConfig(), $this->getInputConfig(), $this->getOracleExpectedConfig()];
+
+        // Case #3. Simple valid configuration with pgqsql base settings.
+        $out[] = [$this->getResolvedPgqsqlConfig(), $this->getInputConfig(), $this->getPgsqlExpectedConfig()];
+
+        // Case #4. Simple valid configuration with sqlite base settings.
+        $out[] = [$this->getResolvedSqliteConfig(), $this->getSqliteInputConfig(), $this->getSqliteExpectedConfig()];
+
+        return $out;
+    }
+
+    /**
+     * Check if master slave connection manages configuration well.
+     *
+     * @param array $resolvedBaseSettings
+     * @param array $settings
+     * @param $expectedOutput
+     *
+     * @dataProvider getMasterSlaveConnectionData
+     */
+    public function testMasterSlaveConnection(array $resolvedBaseSettings, array $settings, array $expectedOutput)
+    {
+        $this->assertEquals(
+            $expectedOutput,
+            (new MasterSlaveConnection(m::mock(Repository::class), $resolvedBaseSettings))->resolve($settings)
+        );
+    }
+
+    /**
+     * Returns dummy input configuration for testing.
+     *
+     * @return array
+     */
+    private function getInputConfig()
+    {
+        return [
             'driver'    => 'mysql',
             'host'      => 'localhost',
             'port'      => '3306',
@@ -47,8 +89,16 @@ class MasterSlaveConnectionTest extends PHPUnit_Framework_TestCase
                 ],
             ],
         ];
+    }
 
-        $dummyExpectedConfig = [
+    /**
+     * Returns dummy expected result configuration for testing.
+     *
+     * @return array
+     */
+    private function getExpectedConfig()
+    {
+        return [
             'wrapperClass' => MasterSlaveDoctrineWrapper::class,
             'driver'       => 'pdo_mysql',
             'slaves'       => [
@@ -84,27 +134,50 @@ class MasterSlaveConnectionTest extends PHPUnit_Framework_TestCase
                 'prefix'      => 'prefix'
             ],
         ];
+    }
 
-        // Case #0. Simple valid configuration with mysql base settings.
-        $resolvedBaseSettings = [
-            'driver'      => 'pdo_mysql',
-            'host'        => 'localhost',
-            'dbname'      => 'test',
-            'user'        => 'homestead',
-            'password'    => 'secret',
-            'charset'     => 'charset',
-            'port'        => 'port',
-            'unix_socket' => 'unix_socket',
-            'prefix'      => 'prefix'
+    /**
+     * Returns dummy input configuration where configuration is only set in read and write nodes.
+     *
+     * @return array
+     */
+    private function getNodesInputConfig()
+    {
+        return [
+            'write' => [
+                'port'     => 3307,
+                'password' => 'secret1',
+                'host'     => 'localhost',
+                'database' => 'test',
+                'username' => 'homestead'
+            ],
+            'read' => [
+                [
+                    'port'     => 3308,
+                    'database' => 'test2',
+                    'host'     => 'localhost',
+                    'username' => 'homestead',
+                    'password' => 'secret'
+                ],
+                [
+                    'host'     => 'localhost2',
+                    'port'     => 3309,
+                    'database' => 'test',
+                    'username' => 'homestead',
+                    'password' => 'secret'
+                ],
+            ],
         ];
-        $out[] = [$resolvedBaseSettings, $dummyInputConfig, $dummyExpectedConfig];
+    }
 
-        // Case #1. Configuration is only set in the read/wriet nodes.
-        $resolvedBaseSettings = [
-            'driver'      => 'pdo_mysql',
-        ];
-
-        $expectedConfig = [
+    /**
+     * Returns dummy expected output configuration where configuration is only set in read and write nodes.
+     *
+     * @return array
+     */
+    private function getNodesExpectedConfig()
+    {
+        return [
             'wrapperClass' => MasterSlaveDoctrineWrapper::class,
             'driver'       => 'pdo_mysql',
             'slaves'       => [
@@ -131,75 +204,47 @@ class MasterSlaveConnectionTest extends PHPUnit_Framework_TestCase
                 'port'     => '3307',
             ],
         ];
+    }
 
-        $inputConfig = [
-            'write' => [
-                'port'     => 3307,
-                'password' => 'secret1',
-                'host'     => 'localhost',
-                'database' => 'test',
-                'username' => 'homestead'
-            ],
-            'read' => [
-                [
-                    'port'     => 3308,
-                    'database' => 'test2',
-                    'host'     => 'localhost',
-                    'username' => 'homestead',
-                    'password' => 'secret'
-                ],
-                [
-                    'host'     => 'localhost2',
-                    'port'     => 3309,
-                    'database' => 'test',
-                    'username' => 'homestead',
-                    'password' => 'secret'
-                ],
-            ],
-        ];
-        $out[] = [$resolvedBaseSettings, $inputConfig, $expectedConfig];
-
-        // Case #2. Simple valid configuration with oracle base settings.
-        $expectedConfigOracle                   = $expectedConfig;
+    /**
+     * Returns dummy expected result configuration for testing oracle connections.
+     *
+     * @return array
+     */
+    private function getOracleExpectedConfig()
+    {
+        $expectedConfigOracle                   = $this->getNodesExpectedConfig();
         $expectedConfigOracle['driver']         = 'oci8';
         $expectedConfigOracle['master']['user'] = 'homestead1';
 
-        $resolvedBaseSettings = [
-            'driver'      => 'oci8',
-            'host'        => 'localhost',
-            'dbname'      => 'test',
-            'user'        => 'homestead',
-            'password'    => 'secret',
-            'port'        => 'port',
-        ];
-        $out[] = [$resolvedBaseSettings, $dummyInputConfig, $expectedConfigOracle];
+        return $expectedConfigOracle;
+    }
 
-        // Case #3. Simple valid configuration with pgqsql base settings.
-        $expectedConfigPgsql                         = $expectedConfig;
+    /**
+     * Returns dummy expected result configuration for testing pgsql connections.
+     *
+     * @return array
+     */
+    private function getPgsqlExpectedConfig()
+    {
+        $expectedConfigPgsql                         = $this->getNodesExpectedConfig();
         $expectedConfigPgsql['driver']               = 'pgsql';
         $expectedConfigPgsql['master']['user']       = 'homestead1';
         $expectedConfigPgsql['master']['sslmode']    = 'sslmode';
         $expectedConfigPgsql['slaves'][0]['sslmode'] = 'sslmode';
         $expectedConfigPgsql['slaves'][1]['sslmode'] = 'sslmode';
 
-        $resolvedBaseSettings = [
-            'driver'      => 'pgsql',
-            'host'        => 'localhost',
-            'dbname'      => 'test',
-            'user'        => 'homestead',
-            'password'    => 'secret',
-            'port'        => 'port',
-            'sslmode'     => 'sslmode',
-        ];
-        $out[] = [$resolvedBaseSettings, $dummyInputConfig, $expectedConfigPgsql];
+        return $expectedConfigPgsql;
+    }
 
-        // Case #4. Simple valid configuration with sqlite base settings.
-        $inputConfigSqlite = $dummyInputConfig;
-        unset($inputConfigSqlite['read'][0]['database']);
-        unset($inputConfigSqlite['read'][1]['database']);
-        unset($inputConfigSqlite['write']['database']);
-
-        $expectedConfigSqlite = [
+    /**
+     * Returns dummy expected result configuration for testing Sqlite connections.
+     *
+     * @return array
+     */
+    private function getSqliteExpectedConfig()
+    {
+        return [
             'wrapperClass' => MasterSlaveDoctrineWrapper::class,
             'driver'       => 'pdo_sqlite',
             'slaves'       => [
@@ -227,33 +272,91 @@ class MasterSlaveConnectionTest extends PHPUnit_Framework_TestCase
                 'path'     => ':memory',
             ],
         ];
+    }
 
-        $resolvedBaseSettings = [
+    /**
+     * Returns dummy input configuration for testing Sqlite connections.
+     *
+     * @return array
+     */
+    private function getSqliteInputConfig()
+    {
+        $inputConfigSqlite = $this->getInputConfig();
+        unset($inputConfigSqlite['read'][0]['database']);
+        unset($inputConfigSqlite['read'][1]['database']);
+        unset($inputConfigSqlite['write']['database']);
+
+        return $inputConfigSqlite;
+    }
+
+    /**
+     * Returns already resolved mysql configuration.
+     *
+     * @return array
+     */
+    private function getResolvedMysqlConfig()
+    {
+        return [
+            'driver'      => 'pdo_mysql',
+            'host'        => 'localhost',
+            'dbname'      => 'test',
+            'user'        => 'homestead',
+            'password'    => 'secret',
+            'charset'     => 'charset',
+            'port'        => 'port',
+            'unix_socket' => 'unix_socket',
+            'prefix'      => 'prefix'
+        ];
+    }
+
+    /**
+     * Returns already resolved oci configuration.
+     *
+     * @return array
+     */
+    private function getResolvedOracleConfig()
+    {
+        return [
+            'driver'      => 'oci8',
+            'host'        => 'localhost',
+            'dbname'      => 'test',
+            'user'        => 'homestead',
+            'password'    => 'secret',
+            'port'        => 'port',
+        ];
+    }
+
+    /**
+     * Returns already resolved sqlite configuration.
+     *
+     * @return array
+     */
+    private function getResolvedSqliteConfig()
+    {
+        return [
             'driver'   => 'pdo_sqlite',
             'path'     => ':memory',
             'user'     => 'homestead',
             'password' => 'secret',
             'memory'   => true
         ];
-        $out[] = [$resolvedBaseSettings, $inputConfigSqlite, $expectedConfigSqlite];
-
-        return $out;
     }
 
     /**
-     * Check if master slave connection manages configuration well.
+     * Returns already resolved pgsql configuration.
      *
-     * @param array $resolvedBaseSettings
-     * @param array $settings
-     * @param $expectedOutput
-     *
-     * @dataProvider getMasterSlaveConnectionData
+     * @return array
      */
-    public function testMasterSlaveConnection(array $resolvedBaseSettings, array $settings, array $expectedOutput)
+    private function getResolvedPgqsqlConfig()
     {
-        $this->assertEquals(
-            $expectedOutput,
-            (new MasterSlaveConnection(m::mock(Repository::class), $resolvedBaseSettings))->resolve($settings)
-        );
+        return [
+            'driver'      => 'pgsql',
+            'host'        => 'localhost',
+            'dbname'      => 'test',
+            'user'        => 'homestead',
+            'password'    => 'secret',
+            'port'        => 'port',
+            'sslmode'     => 'sslmode',
+        ];
     }
 }

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -22,7 +22,6 @@ use LaravelDoctrine\ORM\Configuration\MetaData\MetaDataManager;
 use LaravelDoctrine\ORM\EntityManagerFactory;
 use LaravelDoctrine\ORM\Loggers\Logger;
 use LaravelDoctrine\ORM\Resolvers\EntityListenerResolver as LaravelDoctrineEntityListenerResolver;
-
 use Mockery as m;
 use Mockery\Mock;
 
@@ -711,38 +710,11 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
     {
         $out = [];
 
-        $dummyInputConfig = [
-            'driver'    => 'mysql',
-            'host'      => 'localhost',
-            'port'      => '3306',
-            'database'  => 'test',
-            'username'  => 'homestead',
-            'password'  => 'secret',
-            'charset'   => 'utf8',
-            'collation' => 'utf8_unicode_ci',
-            'prefix'    => '',
-            'strict'    => false,
-            'engine'    => null,
-            'write'     => [
-                'port' => 3307,
-            ],
-            'read' => [
-                [
-                    'port'     => 3308,
-                    'database' => 'test2',
-                ],
-                [
-                    'host' => 'localhost2',
-                    'port' => 3309
-                ],
-            ],
-        ];
-
         // Case #0. Simple valid configuration, everything should go well.
-        $out[] = [$dummyInputConfig];
+        $out[] = [$this->getDummyBaseInputConfig()];
 
         //Case #1. No read DBs set.
-        $inputConfig = $dummyInputConfig;
+        $inputConfig = $this->getDummyBaseInputConfig();
         unset($inputConfig['read']);
 
         $out[] = [
@@ -752,7 +724,7 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
         ];
 
         //Case #2. 'read' isn't an array
-        $inputConfig         = $dummyInputConfig;
+        $inputConfig         = $this->getDummyBaseInputConfig();
         $inputConfig['read'] = 'test';
 
         $out[] = [
@@ -762,7 +734,7 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
         ];
 
         //Case #3. 'read' has non array entries.
-        $inputConfig           = $dummyInputConfig;
+        $inputConfig           = $this->getDummyBaseInputConfig();
         $inputConfig['read'][] = 'test';
 
         $out[] = [
@@ -771,14 +743,24 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
             "Parameter 'read' must be an array containing multiple arrays."
         ];
 
-        //Case #4. 'read' has empty entries
-        $inputConfig           = $dummyInputConfig;
+        //Case #4. 'read' has empty entries.
+        $inputConfig           = $this->getDummyBaseInputConfig();
         $inputConfig['read'][] = [];
 
         $out[] = [
             $inputConfig,
             \InvalidArgumentException::class,
             "Parameter 'read' config no. 2 is empty."
+        ];
+
+        //Case #5. 'read' has empty first entry. (reported by maxbrokman.)
+        $inputConfig            = $this->getDummyBaseInputConfig();
+        $inputConfig['read'][0] = [];
+
+        $out[] = [
+            $inputConfig,
+            \InvalidArgumentException::class,
+            "Parameter 'read' config no. 0 is empty."
         ];
 
         return $out;
@@ -845,6 +827,41 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
     protected function tearDown()
     {
         m::close();
+    }
+
+    /**
+     * Returns dummy base config for testing.
+     *
+     * @return array
+     */
+    private function getDummyBaseInputConfig()
+    {
+        return [
+            'driver'    => 'mysql',
+            'host'      => 'localhost',
+            'port'      => '3306',
+            'database'  => 'test',
+            'username'  => 'homestead',
+            'password'  => 'secret',
+            'charset'   => 'utf8',
+            'collation' => 'utf8_unicode_ci',
+            'prefix'    => '',
+            'strict'    => false,
+            'engine'    => null,
+            'write'     => [
+                'port' => 3307,
+            ],
+            'read' => [
+                [
+                    'port'     => 3308,
+                    'database' => 'test2',
+                ],
+                [
+                    'host' => 'localhost2',
+                    'port' => 3309
+                ],
+            ],
+        ];
     }
 }
 

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -22,6 +22,7 @@ use LaravelDoctrine\ORM\Configuration\MetaData\MetaDataManager;
 use LaravelDoctrine\ORM\EntityManagerFactory;
 use LaravelDoctrine\ORM\Loggers\Logger;
 use LaravelDoctrine\ORM\Resolvers\EntityListenerResolver as LaravelDoctrineEntityListenerResolver;
+
 use Mockery as m;
 use Mockery\Mock;
 
@@ -484,8 +485,11 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
 
     /**
      * MOCKS
+     *
+     * @param array $driverConfig
+     * @param bool  $strictCallCountChecking
      */
-    protected function mockConfig()
+    protected function mockConfig($driverConfig = ['driver' => 'mysql'], $strictCallCountChecking = true)
     {
         $this->config = m::mock(Repository::class);
 
@@ -495,10 +499,11 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
                      ->andReturn('array');
 
         foreach ($this->caches as $cache) {
-            $this->config->shouldReceive('get')
+            $expectation = $this->config->shouldReceive('get')
                          ->with('doctrine.cache.' . $cache . '.driver', 'array')
-                         ->atLeast()->once()
                          ->andReturn('array');
+
+            $strictCallCountChecking ? $expectation->once() : $expectation->never();
         }
 
         $this->config->shouldReceive('has')
@@ -509,21 +514,25 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
         $this->config->shouldReceive('get')
                      ->with('database.connections.mysql')
                      ->once()
-                     ->andReturn([
-                         'driver' => 'mysql'
-                     ]);
+                     ->andReturn($driverConfig);
 
-        $this->config->shouldReceive('get')
+        $expectation = $this->config->shouldReceive('get')
                      ->with('doctrine.custom_datetime_functions')
-                     ->once()->andReturn(['datetime']);
+                     ->andReturn(['datetime']);
 
-        $this->config->shouldReceive('get')
+        $strictCallCountChecking ? $expectation->once() : $expectation->never();
+
+        $expectation = $this->config->shouldReceive('get')
                      ->with('doctrine.custom_numeric_functions')
-                     ->once()->andReturn(['numeric']);
+                     ->andReturn(['numeric']);
 
-        $this->config->shouldReceive('get')
+        $strictCallCountChecking ? $expectation->once() : $expectation->never();
+
+        $expectation = $this->config->shouldReceive('get')
                      ->with('doctrine.custom_string_functions')
-                     ->once()->andReturn(['string']);
+                     ->andReturn(['string']);
+
+        $strictCallCountChecking ? $expectation->once() : $expectation->never();
     }
 
     protected function mockCache()
@@ -691,6 +700,146 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
                         ->once()->andReturn($strategy);
 
         $this->configuration->shouldReceive('setNamingStrategy')->once()->with($strategy);
+    }
+
+    /**
+     * Data provider for testMasterSlaveConnection.
+     *
+     * @return array
+     */
+    public function getTestMasterSlaveConnectionData()
+    {
+        $out = [];
+
+        $dummyInputConfig = [
+            'driver'    => 'mysql',
+            'host'      => 'localhost',
+            'port'      => '3306',
+            'database'  => 'test',
+            'username'  => 'homestead',
+            'password'  => 'secret',
+            'charset'   => 'utf8',
+            'collation' => 'utf8_unicode_ci',
+            'prefix'    => '',
+            'strict'    => false,
+            'engine'    => null,
+            'write'     => [
+                'port' => 3307,
+            ],
+            'read' => [
+                [
+                    'port'     => 3308,
+                    'database' => 'test2',
+                ],
+                [
+                    'host' => 'localhost2',
+                    'port' => 3309
+                ],
+            ],
+        ];
+
+        // Case #0. Simple valid configuration, everything should go well.
+        $out[] = [$dummyInputConfig];
+
+        //Case #1. No read DBs set.
+        $inputConfig = $dummyInputConfig;
+        unset($inputConfig['read']);
+
+        $out[] = [
+            $inputConfig,
+            \InvalidArgumentException::class,
+            "Parameter 'read' must be set for read/write config."
+        ];
+
+        //Case #2. 'read' isn't an array
+        $inputConfig         = $dummyInputConfig;
+        $inputConfig['read'] = 'test';
+
+        $out[] = [
+            $inputConfig,
+            \InvalidArgumentException::class,
+            "Parameter 'read' must be an array containing multiple arrays."
+        ];
+
+        //Case #3. 'read' has non array entries.
+        $inputConfig           = $dummyInputConfig;
+        $inputConfig['read'][] = 'test';
+
+        $out[] = [
+            $inputConfig,
+            \InvalidArgumentException::class,
+            "Parameter 'read' must be an array containing multiple arrays."
+        ];
+
+        //Case #4. 'read' has empty entries
+        $inputConfig           = $dummyInputConfig;
+        $inputConfig['read'][] = [];
+
+        $out[] = [
+            $inputConfig,
+            \InvalidArgumentException::class,
+            "Parameter 'read' config no. 2 is empty."
+        ];
+
+        return $out;
+    }
+
+    /**
+     * Check if config is handled correctly.
+     *
+     * @param array  $inputConfig
+     * @param string $expectedException
+     * @param string $msg
+     *
+     * @dataProvider getTestMasterSlaveConnectionData
+     */
+    public function testMasterSlaveConnection(
+        array $inputConfig,
+        $expectedException = '',
+        $msg = ''
+    ) {
+        m::resetContainer();
+
+        $this->mockApp();
+        $this->mockResolver();
+        $this->mockConfig($inputConfig, empty($expectedException));
+
+        $this->cache = m::mock(CacheManager::class);
+        $this->cache->shouldReceive('driver')
+            ->times(empty($expectedException) ? 4 : 1)
+            ->andReturn(new ArrayCache());
+
+        $this->setup = m::mock(Setup::class);
+        $this->setup->shouldReceive('createConfiguration')->once()->andReturn($this->configuration);
+
+        $this->connection = m::mock(ConnectionManager::class);
+        $this->connection->shouldReceive('driver')
+            ->once()
+            ->with('mysql', $inputConfig)
+            ->andReturn(['driver' => 'pdo_mysql']);
+
+        $factory = new EntityManagerFactory(
+            $this->container,
+            $this->setup,
+            $this->meta,
+            $this->connection,
+            $this->cache,
+            $this->config,
+            $this->listenerResolver
+        );
+
+        if (!empty($expectedException)) {
+            $this->setExpectedException($expectedException, $msg);
+        } else {
+            $this->disableDebugbar();
+            $this->disableCustomCacheNamespace();
+            $this->disableSecondLevelCaching();
+            $this->disableCustomFunctions();
+            $this->enableLaravelNamingStrategy();
+        }
+
+        $this->settings['connection'] = 'mysql';
+        $factory->create($this->settings);
     }
 
     protected function tearDown()


### PR DESCRIPTION
### Changes proposed in this pull request:
- Add support for master slave configuration.

This PR doesn't have breaking changes so long as users don't have **random** _read_ or _write_ keys in their connection configurations.

Example master/slave connection configuration:

```php
[
            'driver'    => 'mysql',
            'host'      => 'localhost',
            'port'      => '3306',
            'database'  => 'test',
            'username'  => 'homestead',
            'password'  => 'secret',
            'write'     => [
                'port'      => 3307,
                'user'      => 'homestead1',
                'password'  => 'secret1',
            ],
            'read' => [
                [
                    'port'     => 3308,
                    'database' => 'test2',
                ],
                [
                    'host' => 'localhost2',
                    'port' => 3309
                ],
            ],
        ];
```

Settings can be specified different for each read/write configuration or you can just specify your base settings and override them in a specific read/write configuration (as in example). 