### PR TITLE
[FIX] Presence verifier on lumen

### DIFF
--- a/src/Validation/PresenceVerifierProvider.php
+++ b/src/Validation/PresenceVerifierProvider.php
@@ -2,6 +2,7 @@
 
 namespace LaravelDoctrine\ORM\Validation;
 
+use Illuminate\Validation\Factory;
 use Illuminate\Validation\ValidationServiceProvider;
 
 class PresenceVerifierProvider extends ValidationServiceProvider
@@ -12,6 +13,27 @@ class PresenceVerifierProvider extends ValidationServiceProvider
      * @var bool
      */
     protected $defer = true;
+
+    /**
+     * Register the validation factory.
+     *
+     * @return void
+     */
+    protected function registerValidationFactory()
+    {
+        $this->app->singleton('validator', function ($app) {
+            $validator = new Factory($app['translator'], $app);
+
+            // The validation presence verifier is responsible for determining the existence of
+            // values in a given data collection which is typically a relational database or
+            // other persistent data stores. It is used to check for "uniqueness" as well.
+            if (isset($app['registry']) && isset($app['validation.presence'])) {
+                $validator->setPresenceVerifier($app['validation.presence']);
+            }
+
+            return $validator;
+        });
+    }
 
     /**
      * Register the database presence verifier.


### PR DESCRIPTION
### Changes proposed in this pull request:
- Unbind default framework binding implementations of 'validator' (if wanting to use doctrine presence)
- Tweak binding of  `PresenceVerifierProvider` to account for the removal of the default  'validator' binding (if wanting to use doctrine presence)
- Ensure the default implementation of `ValidationServiceProvider` has a db instance to use when checking to see if it should set the presence verifier (when using the default presence)