### PR TITLE
[FIX] Convert cache lifetime to minutes for Laravel

### DIFF
--- a/src/Configuration/Cache/IlluminateCacheAdapter.php
+++ b/src/Configuration/Cache/IlluminateCacheAdapter.php
@@ -57,9 +57,9 @@ class IlluminateCacheAdapter extends CacheProvider
         // Laravel cache system accept expire times in minutes
         // while Doctrine accept it in seconds, so we need to convert $lifeTime from seconds to minutes
         // before passing it to Laravel cache repository
-        $lifeTime_minutes = $lifeTime / 60;
+        $lifeTimeMinutes = $lifeTime / 60;
 
-        return $this->cache->put($id, $data, $lifeTime_minutes);
+        return $this->cache->put($id, $data, $lifeTimeMinutes);
     }
 
     /**

--- a/src/Configuration/Cache/IlluminateCacheAdapter.php
+++ b/src/Configuration/Cache/IlluminateCacheAdapter.php
@@ -54,10 +54,11 @@ class IlluminateCacheAdapter extends CacheProvider
             return $this->cache->forever($id, $data);
         }
 
-        // Laravel cache system accept expire times in minutes 
-        // while Doctrine accept it in seconds, so we need to convert $lifeTime to minutes
+        // Laravel cache system accept expire times in minutes
+        // while Doctrine accept it in seconds, so we need to convert $lifeTime from seconds to minutes
         // before passing it to Laravel cache repository
-        $lifeTime_minutes = $lifeTime/60;
+        $lifeTime_minutes = $lifeTime / 60;
+
         return $this->cache->put($id, $data, $lifeTime_minutes);
     }
 

--- a/src/Configuration/Cache/IlluminateCacheAdapter.php
+++ b/src/Configuration/Cache/IlluminateCacheAdapter.php
@@ -54,7 +54,11 @@ class IlluminateCacheAdapter extends CacheProvider
             return $this->cache->forever($id, $data);
         }
 
-        return $this->cache->put($id, $data, $lifeTime);
+        // Laravel cache system accept expire times in minutes 
+        // while Doctrine accept it in seconds, so we need to convert $lifeTime to minutes
+        // before passing it to Laravel cache repository
+        $lifeTime_minutes = $lifeTime/60;
+        return $this->cache->put($id, $data, $lifeTime_minutes);
     }
 
     /**

--- a/tests/Configuration/Cache/IlluminateCacheAdapterTest.php
+++ b/tests/Configuration/Cache/IlluminateCacheAdapterTest.php
@@ -77,7 +77,7 @@ class IlluminateCacheAdapterTest extends PHPUnit_Framework_TestCase
                          ->once()->andReturn('cacheKey');
 
         $this->repository->shouldReceive('put')
-                         ->with('[1][cacheKey]', 'data', 60)
+                         ->with('[1][cacheKey]', 'data', 1)
                          ->once()->andReturn(true);
 
         $this->assertTrue($this->cache->save(1, 'data', 60));


### PR DESCRIPTION
### Changes proposed in this pull request:
Fix the issue https://github.com/laravel-doctrine/orm/issues/216
(Doctrine caching methods accept TTL in seconds, but Laravel use minutes)
This fix convert TTL to minutes before passing it to Laravel Cache repository.