### PR TITLE
[FEATURE] Add support for default table options in configuration

### DIFF
--- a/src/Configuration/Connections/MysqlConnection.php
+++ b/src/Configuration/Connections/MysqlConnection.php
@@ -21,7 +21,7 @@ class MysqlConnection extends Connection
             'port'                => array_get($settings, 'port'),
             'unix_socket'         => array_get($settings, 'unix_socket'),
             'prefix'              => array_get($settings, 'prefix'),
-            'defaultTableOptions' => array_get($settings, 'defaultTableOptions'),
+            'defaultTableOptions' => array_get($settings, 'defaultTableOptions', []),
         ];
     }
 }

--- a/src/Configuration/Connections/MysqlConnection.php
+++ b/src/Configuration/Connections/MysqlConnection.php
@@ -12,15 +12,15 @@ class MysqlConnection extends Connection
     public function resolve(array $settings = [])
     {
         return [
-            'driver' => 'pdo_mysql',
-            'host' => array_get($settings, 'host'),
-            'dbname' => array_get($settings, 'database'),
-            'user' => array_get($settings, 'username'),
-            'password' => array_get($settings, 'password'),
-            'charset' => array_get($settings, 'charset'),
-            'port' => array_get($settings, 'port'),
-            'unix_socket' => array_get($settings, 'unix_socket'),
-            'prefix' => array_get($settings, 'prefix'),
+            'driver'              => 'pdo_mysql',
+            'host'                => array_get($settings, 'host'),
+            'dbname'              => array_get($settings, 'database'),
+            'user'                => array_get($settings, 'username'),
+            'password'            => array_get($settings, 'password'),
+            'charset'             => array_get($settings, 'charset'),
+            'port'                => array_get($settings, 'port'),
+            'unix_socket'         => array_get($settings, 'unix_socket'),
+            'prefix'              => array_get($settings, 'prefix'),
             'defaultTableOptions' => array_get($settings, 'defaultTableOptions'),
         ];
     }

--- a/src/Configuration/Connections/MysqlConnection.php
+++ b/src/Configuration/Connections/MysqlConnection.php
@@ -12,15 +12,16 @@ class MysqlConnection extends Connection
     public function resolve(array $settings = [])
     {
         return [
-            'driver'      => 'pdo_mysql',
-            'host'        => array_get($settings, 'host'),
-            'dbname'      => array_get($settings, 'database'),
-            'user'        => array_get($settings, 'username'),
-            'password'    => array_get($settings, 'password'),
-            'charset'     => array_get($settings, 'charset'),
-            'port'        => array_get($settings, 'port'),
+            'driver' => 'pdo_mysql',
+            'host' => array_get($settings, 'host'),
+            'dbname' => array_get($settings, 'database'),
+            'user' => array_get($settings, 'username'),
+            'password' => array_get($settings, 'password'),
+            'charset' => array_get($settings, 'charset'),
+            'port' => array_get($settings, 'port'),
             'unix_socket' => array_get($settings, 'unix_socket'),
-            'prefix'      => array_get($settings, 'prefix'),
+            'prefix' => array_get($settings, 'prefix'),
+            'defaultTableOptions' => array_get($settings, 'defaultTableOptions'),
         ];
     }
 }

--- a/src/Configuration/Connections/OracleConnection.php
+++ b/src/Configuration/Connections/OracleConnection.php
@@ -20,7 +20,7 @@ class OracleConnection extends Connection
             'charset'             => array_get($settings, 'charset'),
             'port'                => array_get($settings, 'port'),
             'prefix'              => array_get($settings, 'prefix'),
-            'defaultTableOptions' => array_get($settings, 'defaultTableOptions'),
+            'defaultTableOptions' => array_get($settings, 'defaultTableOptions', []),
         ];
     }
 }

--- a/src/Configuration/Connections/OracleConnection.php
+++ b/src/Configuration/Connections/OracleConnection.php
@@ -12,14 +12,14 @@ class OracleConnection extends Connection
     public function resolve(array $settings = [])
     {
         return [
-            'driver' => 'oci8',
-            'host' => array_get($settings, 'host'),
-            'dbname' => array_get($settings, 'database'),
-            'user' => array_get($settings, 'username'),
-            'password' => array_get($settings, 'password'),
-            'charset' => array_get($settings, 'charset'),
-            'port' => array_get($settings, 'port'),
-            'prefix' => array_get($settings, 'prefix'),
+            'driver'              => 'oci8',
+            'host'                => array_get($settings, 'host'),
+            'dbname'              => array_get($settings, 'database'),
+            'user'                => array_get($settings, 'username'),
+            'password'            => array_get($settings, 'password'),
+            'charset'             => array_get($settings, 'charset'),
+            'port'                => array_get($settings, 'port'),
+            'prefix'              => array_get($settings, 'prefix'),
             'defaultTableOptions' => array_get($settings, 'defaultTableOptions'),
         ];
     }

--- a/src/Configuration/Connections/OracleConnection.php
+++ b/src/Configuration/Connections/OracleConnection.php
@@ -12,14 +12,15 @@ class OracleConnection extends Connection
     public function resolve(array $settings = [])
     {
         return [
-            'driver'   => 'oci8',
-            'host'     => array_get($settings, 'host'),
-            'dbname'   => array_get($settings, 'database'),
-            'user'     => array_get($settings, 'username'),
+            'driver' => 'oci8',
+            'host' => array_get($settings, 'host'),
+            'dbname' => array_get($settings, 'database'),
+            'user' => array_get($settings, 'username'),
             'password' => array_get($settings, 'password'),
-            'charset'  => array_get($settings, 'charset'),
-            'port'     => array_get($settings, 'port'),
-            'prefix'   => array_get($settings, 'prefix'),
+            'charset' => array_get($settings, 'charset'),
+            'port' => array_get($settings, 'port'),
+            'prefix' => array_get($settings, 'prefix'),
+            'defaultTableOptions' => array_get($settings, 'defaultTableOptions'),
         ];
     }
 }

--- a/src/Configuration/Connections/PgsqlConnection.php
+++ b/src/Configuration/Connections/PgsqlConnection.php
@@ -12,15 +12,16 @@ class PgsqlConnection extends Connection
     public function resolve(array $settings = [])
     {
         return [
-            'driver'   => 'pdo_pgsql',
-            'host'     => array_get($settings, 'host'),
-            'dbname'   => array_get($settings, 'database'),
-            'user'     => array_get($settings, 'username'),
+            'driver' => 'pdo_pgsql',
+            'host' => array_get($settings, 'host'),
+            'dbname' => array_get($settings, 'database'),
+            'user' => array_get($settings, 'username'),
             'password' => array_get($settings, 'password'),
-            'charset'  => array_get($settings, 'charset'),
-            'port'     => array_get($settings, 'port'),
-            'sslmode'  => array_get($settings, 'sslmode'),
-            'prefix'   => array_get($settings, 'prefix'),
+            'charset' => array_get($settings, 'charset'),
+            'port' => array_get($settings, 'port'),
+            'sslmode' => array_get($settings, 'sslmode'),
+            'prefix' => array_get($settings, 'prefix'),
+            'defaultTableOptions' => array_get($settings, 'defaultTableOptions'),
         ];
     }
 }

--- a/src/Configuration/Connections/PgsqlConnection.php
+++ b/src/Configuration/Connections/PgsqlConnection.php
@@ -21,7 +21,7 @@ class PgsqlConnection extends Connection
             'port'                => array_get($settings, 'port'),
             'sslmode'             => array_get($settings, 'sslmode'),
             'prefix'              => array_get($settings, 'prefix'),
-            'defaultTableOptions' => array_get($settings, 'defaultTableOptions'),
+            'defaultTableOptions' => array_get($settings, 'defaultTableOptions', []),
         ];
     }
 }

--- a/src/Configuration/Connections/PgsqlConnection.php
+++ b/src/Configuration/Connections/PgsqlConnection.php
@@ -12,15 +12,15 @@ class PgsqlConnection extends Connection
     public function resolve(array $settings = [])
     {
         return [
-            'driver' => 'pdo_pgsql',
-            'host' => array_get($settings, 'host'),
-            'dbname' => array_get($settings, 'database'),
-            'user' => array_get($settings, 'username'),
-            'password' => array_get($settings, 'password'),
-            'charset' => array_get($settings, 'charset'),
-            'port' => array_get($settings, 'port'),
-            'sslmode' => array_get($settings, 'sslmode'),
-            'prefix' => array_get($settings, 'prefix'),
+            'driver'              => 'pdo_pgsql',
+            'host'                => array_get($settings, 'host'),
+            'dbname'              => array_get($settings, 'database'),
+            'user'                => array_get($settings, 'username'),
+            'password'            => array_get($settings, 'password'),
+            'charset'             => array_get($settings, 'charset'),
+            'port'                => array_get($settings, 'port'),
+            'sslmode'             => array_get($settings, 'sslmode'),
+            'prefix'              => array_get($settings, 'prefix'),
             'defaultTableOptions' => array_get($settings, 'defaultTableOptions'),
         ];
     }

--- a/src/Configuration/Connections/SqliteConnection.php
+++ b/src/Configuration/Connections/SqliteConnection.php
@@ -14,12 +14,13 @@ class SqliteConnection extends Connection
     public function resolve(array $settings = [])
     {
         return [
-            'driver'   => 'pdo_sqlite',
-            'user'     => array_get($settings, 'username'),
+            'driver' => 'pdo_sqlite',
+            'user' => array_get($settings, 'username'),
             'password' => array_get($settings, 'password'),
-            'prefix'   => array_get($settings, 'prefix'),
-            'memory'   => $this->isMemory($settings),
-            'path'     => array_get($settings, 'database')
+            'prefix' => array_get($settings, 'prefix'),
+            'memory' => $this->isMemory($settings),
+            'path' => array_get($settings, 'database'),
+            'defaultTableOptions' => array_get($settings, 'defaultTableOptions'),
         ];
     }
 

--- a/src/Configuration/Connections/SqliteConnection.php
+++ b/src/Configuration/Connections/SqliteConnection.php
@@ -20,7 +20,7 @@ class SqliteConnection extends Connection
             'prefix'              => array_get($settings, 'prefix'),
             'memory'              => $this->isMemory($settings),
             'path'                => array_get($settings, 'database'),
-            'defaultTableOptions' => array_get($settings, 'defaultTableOptions'),
+            'defaultTableOptions' => array_get($settings, 'defaultTableOptions', []),
         ];
     }
 

--- a/src/Configuration/Connections/SqliteConnection.php
+++ b/src/Configuration/Connections/SqliteConnection.php
@@ -14,12 +14,12 @@ class SqliteConnection extends Connection
     public function resolve(array $settings = [])
     {
         return [
-            'driver' => 'pdo_sqlite',
-            'user' => array_get($settings, 'username'),
-            'password' => array_get($settings, 'password'),
-            'prefix' => array_get($settings, 'prefix'),
-            'memory' => $this->isMemory($settings),
-            'path' => array_get($settings, 'database'),
+            'driver'              => 'pdo_sqlite',
+            'user'                => array_get($settings, 'username'),
+            'password'            => array_get($settings, 'password'),
+            'prefix'              => array_get($settings, 'prefix'),
+            'memory'              => $this->isMemory($settings),
+            'path'                => array_get($settings, 'database'),
             'defaultTableOptions' => array_get($settings, 'defaultTableOptions'),
         ];
     }

--- a/src/Configuration/Connections/SqlsrvConnection.php
+++ b/src/Configuration/Connections/SqlsrvConnection.php
@@ -12,14 +12,15 @@ class SqlsrvConnection extends Connection
     public function resolve(array $settings = [])
     {
         return [
-            'driver'   => 'pdo_sqlsrv',
-            'host'     => array_get($settings, 'host'),
-            'dbname'   => array_get($settings, 'database'),
-            'user'     => array_get($settings, 'username'),
+            'driver' => 'pdo_sqlsrv',
+            'host' => array_get($settings, 'host'),
+            'dbname' => array_get($settings, 'database'),
+            'user' => array_get($settings, 'username'),
             'password' => array_get($settings, 'password'),
-            'port'     => array_get($settings, 'port'),
-            'prefix'   => array_get($settings, 'prefix'),
-            'charset'  => array_get($settings, 'charset'),
+            'port' => array_get($settings, 'port'),
+            'prefix' => array_get($settings, 'prefix'),
+            'charset' => array_get($settings, 'charset'),
+            'defaultTableOptions' => array_get($settings, 'defaultTableOptions'),
         ];
     }
 }

--- a/src/Configuration/Connections/SqlsrvConnection.php
+++ b/src/Configuration/Connections/SqlsrvConnection.php
@@ -20,7 +20,7 @@ class SqlsrvConnection extends Connection
             'port'                => array_get($settings, 'port'),
             'prefix'              => array_get($settings, 'prefix'),
             'charset'             => array_get($settings, 'charset'),
-            'defaultTableOptions' => array_get($settings, 'defaultTableOptions'),
+            'defaultTableOptions' => array_get($settings, 'defaultTableOptions', []),
         ];
     }
 }

--- a/src/Configuration/Connections/SqlsrvConnection.php
+++ b/src/Configuration/Connections/SqlsrvConnection.php
@@ -12,14 +12,14 @@ class SqlsrvConnection extends Connection
     public function resolve(array $settings = [])
     {
         return [
-            'driver' => 'pdo_sqlsrv',
-            'host' => array_get($settings, 'host'),
-            'dbname' => array_get($settings, 'database'),
-            'user' => array_get($settings, 'username'),
-            'password' => array_get($settings, 'password'),
-            'port' => array_get($settings, 'port'),
-            'prefix' => array_get($settings, 'prefix'),
-            'charset' => array_get($settings, 'charset'),
+            'driver'              => 'pdo_sqlsrv',
+            'host'                => array_get($settings, 'host'),
+            'dbname'              => array_get($settings, 'database'),
+            'user'                => array_get($settings, 'username'),
+            'password'            => array_get($settings, 'password'),
+            'port'                => array_get($settings, 'port'),
+            'prefix'              => array_get($settings, 'prefix'),
+            'charset'             => array_get($settings, 'charset'),
             'defaultTableOptions' => array_get($settings, 'defaultTableOptions'),
         ];
     }

--- a/tests/Configuration/Connections/MysqlConnectionTest.php
+++ b/tests/Configuration/Connections/MysqlConnectionTest.php
@@ -36,7 +36,7 @@ class MysqlConnectionTest extends PHPUnit_Framework_TestCase
             'port'                => 'port',
             'unix_socket'         => 'unix_socket',
             'prefix'              => 'prefix',
-            'defaultTableOptions' => 'defaultTableOptions',
+            'defaultTableOptions' => [],
         ]);
 
         $this->assertEquals('pdo_mysql', $resolved['driver']);
@@ -48,7 +48,7 @@ class MysqlConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('port', $resolved['port']);
         $this->assertEquals('unix_socket', $resolved['unix_socket']);
         $this->assertEquals('prefix', $resolved['prefix']);
-        $this->assertEquals('defaultTableOptions', $resolved['defaultTableOptions']);
+        $this->assertCount(0, $resolved['defaultTableOptions']);
     }
 
     protected function tearDown()

--- a/tests/Configuration/Connections/MysqlConnectionTest.php
+++ b/tests/Configuration/Connections/MysqlConnectionTest.php
@@ -27,15 +27,16 @@ class MysqlConnectionTest extends PHPUnit_Framework_TestCase
     public function test_can_resolve()
     {
         $resolved = $this->connection->resolve([
-            'driver'      => 'pdo_mysql',
-            'host'        => 'host',
-            'database'    => 'database',
-            'username'    => 'username',
-            'password'    => 'password',
-            'charset'     => 'charset',
-            'port'        => 'port',
+            'driver' => 'pdo_mysql',
+            'host' => 'host',
+            'database' => 'database',
+            'username' => 'username',
+            'password' => 'password',
+            'charset' => 'charset',
+            'port' => 'port',
             'unix_socket' => 'unix_socket',
-            'prefix'      => 'prefix'
+            'prefix' => 'prefix',
+            'defaultTableOptions' => 'defaultTableOptions',
         ]);
 
         $this->assertEquals('pdo_mysql', $resolved['driver']);
@@ -47,6 +48,7 @@ class MysqlConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('port', $resolved['port']);
         $this->assertEquals('unix_socket', $resolved['unix_socket']);
         $this->assertEquals('prefix', $resolved['prefix']);
+        $this->assertEquals('defaultTableOptions', $resolved['defaultTableOptions']);
     }
 
     protected function tearDown()

--- a/tests/Configuration/Connections/MysqlConnectionTest.php
+++ b/tests/Configuration/Connections/MysqlConnectionTest.php
@@ -27,15 +27,15 @@ class MysqlConnectionTest extends PHPUnit_Framework_TestCase
     public function test_can_resolve()
     {
         $resolved = $this->connection->resolve([
-            'driver' => 'pdo_mysql',
-            'host' => 'host',
-            'database' => 'database',
-            'username' => 'username',
-            'password' => 'password',
-            'charset' => 'charset',
-            'port' => 'port',
-            'unix_socket' => 'unix_socket',
-            'prefix' => 'prefix',
+            'driver'              => 'pdo_mysql',
+            'host'                => 'host',
+            'database'            => 'database',
+            'username'            => 'username',
+            'password'            => 'password',
+            'charset'             => 'charset',
+            'port'                => 'port',
+            'unix_socket'         => 'unix_socket',
+            'prefix'              => 'prefix',
             'defaultTableOptions' => 'defaultTableOptions',
         ]);
 

--- a/tests/Configuration/Connections/OracleConnectionTest.php
+++ b/tests/Configuration/Connections/OracleConnectionTest.php
@@ -35,7 +35,7 @@ class OracleConnectionTest extends PHPUnit_Framework_TestCase
             'charset'             => 'charset',
             'port'                => 'port',
             'prefix'              => 'prefix',
-            'defaultTableOptions' => 'defaultTableOptions',
+            'defaultTableOptions' => [],
         ]);
 
         $this->assertEquals('oci8', $resolved['driver']);
@@ -46,7 +46,7 @@ class OracleConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('charset', $resolved['charset']);
         $this->assertEquals('port', $resolved['port']);
         $this->assertEquals('prefix', $resolved['prefix']);
-        $this->assertEquals('defaultTableOptions', $resolved['defaultTableOptions']);
+        $this->assertCount(0, $resolved['defaultTableOptions']);
     }
 
     protected function tearDown()

--- a/tests/Configuration/Connections/OracleConnectionTest.php
+++ b/tests/Configuration/Connections/OracleConnectionTest.php
@@ -27,14 +27,15 @@ class OracleConnectionTest extends PHPUnit_Framework_TestCase
     public function test_can_resolve()
     {
         $resolved = $this->connection->resolve([
-            'driver'      => 'oci8',
-            'host'        => 'host',
-            'database'    => 'database',
-            'username'    => 'username',
-            'password'    => 'password',
-            'charset'     => 'charset',
-            'port'        => 'port',
-            'prefix'      => 'prefix'
+            'driver' => 'oci8',
+            'host' => 'host',
+            'database' => 'database',
+            'username' => 'username',
+            'password' => 'password',
+            'charset' => 'charset',
+            'port' => 'port',
+            'prefix' => 'prefix',
+            'defaultTableOptions' => 'defaultTableOptions',
         ]);
 
         $this->assertEquals('oci8', $resolved['driver']);
@@ -45,6 +46,7 @@ class OracleConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('charset', $resolved['charset']);
         $this->assertEquals('port', $resolved['port']);
         $this->assertEquals('prefix', $resolved['prefix']);
+        $this->assertEquals('defaultTableOptions', $resolved['defaultTableOptions']);
     }
 
     protected function tearDown()

--- a/tests/Configuration/Connections/OracleConnectionTest.php
+++ b/tests/Configuration/Connections/OracleConnectionTest.php
@@ -27,14 +27,14 @@ class OracleConnectionTest extends PHPUnit_Framework_TestCase
     public function test_can_resolve()
     {
         $resolved = $this->connection->resolve([
-            'driver' => 'oci8',
-            'host' => 'host',
-            'database' => 'database',
-            'username' => 'username',
-            'password' => 'password',
-            'charset' => 'charset',
-            'port' => 'port',
-            'prefix' => 'prefix',
+            'driver'              => 'oci8',
+            'host'                => 'host',
+            'database'            => 'database',
+            'username'            => 'username',
+            'password'            => 'password',
+            'charset'             => 'charset',
+            'port'                => 'port',
+            'prefix'              => 'prefix',
             'defaultTableOptions' => 'defaultTableOptions',
         ]);
 

--- a/tests/Configuration/Connections/PgsqlConnectionTest.php
+++ b/tests/Configuration/Connections/PgsqlConnectionTest.php
@@ -27,15 +27,16 @@ class PgsqlConnectionTest extends PHPUnit_Framework_TestCase
     public function test_can_resolve()
     {
         $resolved = $this->connection->resolve([
-            'driver'   => 'pdo_pgsql',
-            'host'     => 'host',
+            'driver' => 'pdo_pgsql',
+            'host' => 'host',
             'database' => 'database',
             'username' => 'username',
             'password' => 'password',
-            'charset'  => 'charset',
-            'port'     => 'port',
-            'prefix'   => 'prefix',
-            'sslmode'  => 'sslmode'
+            'charset' => 'charset',
+            'port' => 'port',
+            'prefix' => 'prefix',
+            'sslmode' => 'sslmode',
+            'defaultTableOptions' => 'defaultTableOptions',
         ]);
 
         $this->assertEquals('pdo_pgsql', $resolved['driver']);
@@ -47,6 +48,7 @@ class PgsqlConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('port', $resolved['port']);
         $this->assertEquals('sslmode', $resolved['sslmode']);
         $this->assertEquals('prefix', $resolved['prefix']);
+        $this->assertEquals('defaultTableOptions', $resolved['defaultTableOptions']);
     }
 
     protected function tearDown()

--- a/tests/Configuration/Connections/PgsqlConnectionTest.php
+++ b/tests/Configuration/Connections/PgsqlConnectionTest.php
@@ -27,15 +27,15 @@ class PgsqlConnectionTest extends PHPUnit_Framework_TestCase
     public function test_can_resolve()
     {
         $resolved = $this->connection->resolve([
-            'driver' => 'pdo_pgsql',
-            'host' => 'host',
-            'database' => 'database',
-            'username' => 'username',
-            'password' => 'password',
-            'charset' => 'charset',
-            'port' => 'port',
-            'prefix' => 'prefix',
-            'sslmode' => 'sslmode',
+            'driver'              => 'pdo_pgsql',
+            'host'                => 'host',
+            'database'            => 'database',
+            'username'            => 'username',
+            'password'            => 'password',
+            'charset'             => 'charset',
+            'port'                => 'port',
+            'prefix'              => 'prefix',
+            'sslmode'             => 'sslmode',
             'defaultTableOptions' => 'defaultTableOptions',
         ]);
 

--- a/tests/Configuration/Connections/PgsqlConnectionTest.php
+++ b/tests/Configuration/Connections/PgsqlConnectionTest.php
@@ -36,7 +36,7 @@ class PgsqlConnectionTest extends PHPUnit_Framework_TestCase
             'port'                => 'port',
             'prefix'              => 'prefix',
             'sslmode'             => 'sslmode',
-            'defaultTableOptions' => 'defaultTableOptions',
+            'defaultTableOptions' => [],
         ]);
 
         $this->assertEquals('pdo_pgsql', $resolved['driver']);
@@ -48,7 +48,7 @@ class PgsqlConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('port', $resolved['port']);
         $this->assertEquals('sslmode', $resolved['sslmode']);
         $this->assertEquals('prefix', $resolved['prefix']);
-        $this->assertEquals('defaultTableOptions', $resolved['defaultTableOptions']);
+        $this->assertCount(0, $resolved['defaultTableOptions']);
     }
 
     protected function tearDown()

--- a/tests/Configuration/Connections/SqliteConnectionTest.php
+++ b/tests/Configuration/Connections/SqliteConnectionTest.php
@@ -32,7 +32,7 @@ class SqliteConnectionTest extends PHPUnit_Framework_TestCase
             'username'            => 'username',
             'password'            => 'password',
             'prefix'              => 'prefix',
-            'defaultTableOptions' => 'defaultTableOptions',
+            'defaultTableOptions' => [],
         ]);
 
         $this->assertEquals('pdo_sqlite', $resolved['driver']);
@@ -41,7 +41,7 @@ class SqliteConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('prefix', $resolved['prefix']);
         $this->assertFalse($resolved['memory']);
         $this->assertEquals('path', $resolved['path']);
-        $this->assertEquals('defaultTableOptions', $resolved['defaultTableOptions']);
+        $this->assertCount(0, $resolved['defaultTableOptions']);
     }
 
     public function test_can_resolve_with_in_memory_database()

--- a/tests/Configuration/Connections/SqliteConnectionTest.php
+++ b/tests/Configuration/Connections/SqliteConnectionTest.php
@@ -27,11 +27,11 @@ class SqliteConnectionTest extends PHPUnit_Framework_TestCase
     public function test_can_resolve()
     {
         $resolved = $this->connection->resolve([
-            'driver' => 'pdo_sqlite',
-            'database' => 'path',
-            'username' => 'username',
-            'password' => 'password',
-            'prefix' => 'prefix',
+            'driver'              => 'pdo_sqlite',
+            'database'            => 'path',
+            'username'            => 'username',
+            'password'            => 'password',
+            'prefix'              => 'prefix',
             'defaultTableOptions' => 'defaultTableOptions',
         ]);
 
@@ -47,11 +47,11 @@ class SqliteConnectionTest extends PHPUnit_Framework_TestCase
     public function test_can_resolve_with_in_memory_database()
     {
         $resolved = $this->connection->resolve([
-            'driver' => 'pdo_sqlite',
+            'driver'   => 'pdo_sqlite',
             'database' => ':memory',
             'username' => 'username',
             'password' => 'password',
-            'prefix' => 'prefix',
+            'prefix'   => 'prefix',
         ]);
 
         $this->assertEquals('pdo_sqlite', $resolved['driver']);

--- a/tests/Configuration/Connections/SqliteConnectionTest.php
+++ b/tests/Configuration/Connections/SqliteConnectionTest.php
@@ -27,11 +27,12 @@ class SqliteConnectionTest extends PHPUnit_Framework_TestCase
     public function test_can_resolve()
     {
         $resolved = $this->connection->resolve([
-            'driver'   => 'pdo_sqlite',
+            'driver' => 'pdo_sqlite',
             'database' => 'path',
             'username' => 'username',
             'password' => 'password',
-            'prefix'   => 'prefix',
+            'prefix' => 'prefix',
+            'defaultTableOptions' => 'defaultTableOptions',
         ]);
 
         $this->assertEquals('pdo_sqlite', $resolved['driver']);
@@ -40,16 +41,17 @@ class SqliteConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('prefix', $resolved['prefix']);
         $this->assertFalse($resolved['memory']);
         $this->assertEquals('path', $resolved['path']);
+        $this->assertEquals('defaultTableOptions', $resolved['defaultTableOptions']);
     }
 
     public function test_can_resolve_with_in_memory_database()
     {
         $resolved = $this->connection->resolve([
-            'driver'   => 'pdo_sqlite',
+            'driver' => 'pdo_sqlite',
             'database' => ':memory',
             'username' => 'username',
             'password' => 'password',
-            'prefix'   => 'prefix',
+            'prefix' => 'prefix',
         ]);
 
         $this->assertEquals('pdo_sqlite', $resolved['driver']);

--- a/tests/Configuration/Connections/SqlsrvConnectionTest.php
+++ b/tests/Configuration/Connections/SqlsrvConnectionTest.php
@@ -27,14 +27,15 @@ class SqlsrvConnectionTest extends PHPUnit_Framework_TestCase
     public function test_can_resolve()
     {
         $resolved = $this->connection->resolve([
-            'driver'   => 'pdo_sqlsrv',
-            'host'     => 'host',
+            'driver' => 'pdo_sqlsrv',
+            'host' => 'host',
             'database' => 'database',
             'username' => 'username',
             'password' => 'password',
-            'port'     => 'port',
-            'prefix'   => 'prefix',
-            'charset'  => 'charset'
+            'port' => 'port',
+            'prefix' => 'prefix',
+            'charset' => 'charset',
+            'defaultTableOptions' => 'defaultTableOptions',
         ]);
 
         $this->assertEquals('pdo_sqlsrv', $resolved['driver']);
@@ -45,6 +46,7 @@ class SqlsrvConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('port', $resolved['port']);
         $this->assertEquals('prefix', $resolved['prefix']);
         $this->assertEquals('charset', $resolved['charset']);
+        $this->assertEquals('defaultTableOptions', $resolved['defaultTableOptions']);
     }
 
     protected function tearDown()

--- a/tests/Configuration/Connections/SqlsrvConnectionTest.php
+++ b/tests/Configuration/Connections/SqlsrvConnectionTest.php
@@ -35,7 +35,7 @@ class SqlsrvConnectionTest extends PHPUnit_Framework_TestCase
             'port'                => 'port',
             'prefix'              => 'prefix',
             'charset'             => 'charset',
-            'defaultTableOptions' => 'defaultTableOptions',
+            'defaultTableOptions' => [],
         ]);
 
         $this->assertEquals('pdo_sqlsrv', $resolved['driver']);
@@ -46,7 +46,7 @@ class SqlsrvConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('port', $resolved['port']);
         $this->assertEquals('prefix', $resolved['prefix']);
         $this->assertEquals('charset', $resolved['charset']);
-        $this->assertEquals('defaultTableOptions', $resolved['defaultTableOptions']);
+        $this->assertCount(0, $resolved['defaultTableOptions']);
     }
 
     protected function tearDown()

--- a/tests/Configuration/Connections/SqlsrvConnectionTest.php
+++ b/tests/Configuration/Connections/SqlsrvConnectionTest.php
@@ -27,14 +27,14 @@ class SqlsrvConnectionTest extends PHPUnit_Framework_TestCase
     public function test_can_resolve()
     {
         $resolved = $this->connection->resolve([
-            'driver' => 'pdo_sqlsrv',
-            'host' => 'host',
-            'database' => 'database',
-            'username' => 'username',
-            'password' => 'password',
-            'port' => 'port',
-            'prefix' => 'prefix',
-            'charset' => 'charset',
+            'driver'              => 'pdo_sqlsrv',
+            'host'                => 'host',
+            'database'            => 'database',
+            'username'            => 'username',
+            'password'            => 'password',
+            'port'                => 'port',
+            'prefix'              => 'prefix',
+            'charset'             => 'charset',
             'defaultTableOptions' => 'defaultTableOptions',
         ]);
 


### PR DESCRIPTION
### Changes proposed in this pull request:
- Supporting `defaultTaleOptions` in configration resolving. This is supported by doctrine and enables developers to set a default collation on all tables.

I ran into some troubles with the php-cs-fixer config in this project as I was using php-cs-fixer 2.0.. However, I manually ran cs fixer on the files I modified.

I also noticed that StyleCI conflicts with what php cs fixer.. fixes.