### PR TITLE
[FEATURE] Add support for default table options in configuration

### DIFF
--- a/src/Configuration/Connections/MysqlConnection.php
+++ b/src/Configuration/Connections/MysqlConnection.php
@@ -12,15 +12,16 @@ class MysqlConnection extends Connection
     public function resolve(array $settings = [])
     {
         return [
-            'driver'      => 'pdo_mysql',
-            'host'        => array_get($settings, 'host'),
-            'dbname'      => array_get($settings, 'database'),
-            'user'        => array_get($settings, 'username'),
-            'password'    => array_get($settings, 'password'),
-            'charset'     => array_get($settings, 'charset'),
-            'port'        => array_get($settings, 'port'),
-            'unix_socket' => array_get($settings, 'unix_socket'),
-            'prefix'      => array_get($settings, 'prefix'),
+            'driver'                => 'pdo_mysql',
+            'host'                  => array_get($settings, 'host'),
+            'dbname'                => array_get($settings, 'database'),
+            'user'                  => array_get($settings, 'username'),
+            'password'              => array_get($settings, 'password'),
+            'charset'               => array_get($settings, 'charset'),
+            'port'                  => array_get($settings, 'port'),
+            'unix_socket'           => array_get($settings, 'unix_socket'),
+            'prefix'                => array_get($settings, 'prefix'),
+            'defaultTableOptions'   => array_get($settings, 'defaultTableOptions', []),
         ];
     }
 }

--- a/src/Configuration/Connections/OracleConnection.php
+++ b/src/Configuration/Connections/OracleConnection.php
@@ -12,14 +12,15 @@ class OracleConnection extends Connection
     public function resolve(array $settings = [])
     {
         return [
-            'driver'   => 'oci8',
-            'host'     => array_get($settings, 'host'),
-            'dbname'   => array_get($settings, 'database'),
-            'user'     => array_get($settings, 'username'),
-            'password' => array_get($settings, 'password'),
-            'charset'  => array_get($settings, 'charset'),
-            'port'     => array_get($settings, 'port'),
-            'prefix'   => array_get($settings, 'prefix'),
+            'driver'                => 'oci8',
+            'host'                  => array_get($settings, 'host'),
+            'dbname'                => array_get($settings, 'database'),
+            'user'                  => array_get($settings, 'username'),
+            'password'              => array_get($settings, 'password'),
+            'charset'               => array_get($settings, 'charset'),
+            'port'                  => array_get($settings, 'port'),
+            'prefix'                => array_get($settings, 'prefix'),
+            'defaultTableOptions'   => array_get($settings, 'defaultTableOptions', []),
         ];
     }
 }

--- a/src/Configuration/Connections/PgsqlConnection.php
+++ b/src/Configuration/Connections/PgsqlConnection.php
@@ -12,15 +12,15 @@ class PgsqlConnection extends Connection
     public function resolve(array $settings = [])
     {
         return [
-            'driver'   => 'pdo_pgsql',
-            'host'     => array_get($settings, 'host'),
-            'dbname'   => array_get($settings, 'database'),
-            'user'     => array_get($settings, 'username'),
-            'password' => array_get($settings, 'password'),
-            'charset'  => array_get($settings, 'charset'),
-            'port'     => array_get($settings, 'port'),
-            'sslmode'  => array_get($settings, 'sslmode'),
-            'prefix'   => array_get($settings, 'prefix'),
+            'driver'              => 'pdo_pgsql',
+            'host'                => array_get($settings, 'host'),
+            'dbname'              => array_get($settings, 'database'),
+            'user'                => array_get($settings, 'username'),
+            'password'            => array_get($settings, 'password'),
+            'charset'             => array_get($settings, 'charset'),
+            'port'                => array_get($settings, 'port'),
+            'sslmode'             => array_get($settings, 'sslmode'),
+            'prefix'              => array_get($settings, 'prefix'),
             'defaultTableOptions' => array_get($settings, 'defaultTableOptions', []),
         ];
     }

--- a/src/Configuration/Connections/PgsqlConnection.php
+++ b/src/Configuration/Connections/PgsqlConnection.php
@@ -21,6 +21,7 @@ class PgsqlConnection extends Connection
             'port'     => array_get($settings, 'port'),
             'sslmode'  => array_get($settings, 'sslmode'),
             'prefix'   => array_get($settings, 'prefix'),
+            'defaultTableOptions' => array_get($settings, 'defaultTableOptions', []),
         ];
     }
 }

--- a/src/Configuration/Connections/SqliteConnection.php
+++ b/src/Configuration/Connections/SqliteConnection.php
@@ -14,12 +14,12 @@ class SqliteConnection extends Connection
     public function resolve(array $settings = [])
     {
         return [
-            'driver'   => 'pdo_sqlite',
-            'user'     => array_get($settings, 'username'),
-            'password' => array_get($settings, 'password'),
-            'prefix'   => array_get($settings, 'prefix'),
-            'memory'   => $this->isMemory($settings),
-            'path'     => array_get($settings, 'database'),
+            'driver'              => 'pdo_sqlite',
+            'user'                => array_get($settings, 'username'),
+            'password'            => array_get($settings, 'password'),
+            'prefix'              => array_get($settings, 'prefix'),
+            'memory'              => $this->isMemory($settings),
+            'path'                => array_get($settings, 'database'),
             'defaultTableOptions' => array_get($settings, 'defaultTableOptions', []),
         ];
     }

--- a/src/Configuration/Connections/SqliteConnection.php
+++ b/src/Configuration/Connections/SqliteConnection.php
@@ -19,7 +19,8 @@ class SqliteConnection extends Connection
             'password' => array_get($settings, 'password'),
             'prefix'   => array_get($settings, 'prefix'),
             'memory'   => $this->isMemory($settings),
-            'path'     => array_get($settings, 'database')
+            'path'     => array_get($settings, 'database'),
+            'defaultTableOptions' => array_get($settings, 'defaultTableOptions', []),
         ];
     }
 

--- a/src/Configuration/Connections/SqlsrvConnection.php
+++ b/src/Configuration/Connections/SqlsrvConnection.php
@@ -12,14 +12,14 @@ class SqlsrvConnection extends Connection
     public function resolve(array $settings = [])
     {
         return [
-            'driver'   => 'pdo_sqlsrv',
-            'host'     => array_get($settings, 'host'),
-            'dbname'   => array_get($settings, 'database'),
-            'user'     => array_get($settings, 'username'),
-            'password' => array_get($settings, 'password'),
-            'port'     => array_get($settings, 'port'),
-            'prefix'   => array_get($settings, 'prefix'),
-            'charset'  => array_get($settings, 'charset'),
+            'driver'              => 'pdo_sqlsrv',
+            'host'                => array_get($settings, 'host'),
+            'dbname'              => array_get($settings, 'database'),
+            'user'                => array_get($settings, 'username'),
+            'password'            => array_get($settings, 'password'),
+            'port'                => array_get($settings, 'port'),
+            'prefix'              => array_get($settings, 'prefix'),
+            'charset'             => array_get($settings, 'charset'),
             'defaultTableOptions' => array_get($settings, 'defaultTableOptions', []),
         ];
     }

--- a/src/Configuration/Connections/SqlsrvConnection.php
+++ b/src/Configuration/Connections/SqlsrvConnection.php
@@ -20,6 +20,7 @@ class SqlsrvConnection extends Connection
             'port'     => array_get($settings, 'port'),
             'prefix'   => array_get($settings, 'prefix'),
             'charset'  => array_get($settings, 'charset'),
+            'defaultTableOptions' => array_get($settings, 'defaultTableOptions', []),
         ];
     }
 }

--- a/tests/Configuration/Connections/MysqlConnectionTest.php
+++ b/tests/Configuration/Connections/MysqlConnectionTest.php
@@ -35,7 +35,8 @@ class MysqlConnectionTest extends PHPUnit_Framework_TestCase
             'charset'     => 'charset',
             'port'        => 'port',
             'unix_socket' => 'unix_socket',
-            'prefix'      => 'prefix'
+            'prefix'      => 'prefix',
+            'defaultTableOptions' => [],
         ]);
 
         $this->assertEquals('pdo_mysql', $resolved['driver']);
@@ -47,6 +48,7 @@ class MysqlConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('port', $resolved['port']);
         $this->assertEquals('unix_socket', $resolved['unix_socket']);
         $this->assertEquals('prefix', $resolved['prefix']);
+        $this->assertCount(0, $resolved['defaultTableOptions']);
     }
 
     protected function tearDown()

--- a/tests/Configuration/Connections/MysqlConnectionTest.php
+++ b/tests/Configuration/Connections/MysqlConnectionTest.php
@@ -27,15 +27,15 @@ class MysqlConnectionTest extends PHPUnit_Framework_TestCase
     public function test_can_resolve()
     {
         $resolved = $this->connection->resolve([
-            'driver'      => 'pdo_mysql',
-            'host'        => 'host',
-            'database'    => 'database',
-            'username'    => 'username',
-            'password'    => 'password',
-            'charset'     => 'charset',
-            'port'        => 'port',
-            'unix_socket' => 'unix_socket',
-            'prefix'      => 'prefix',
+            'driver'              => 'pdo_mysql',
+            'host'                => 'host',
+            'database'            => 'database',
+            'username'            => 'username',
+            'password'            => 'password',
+            'charset'             => 'charset',
+            'port'                => 'port',
+            'unix_socket'         => 'unix_socket',
+            'prefix'              => 'prefix',
             'defaultTableOptions' => [],
         ]);
 

--- a/tests/Configuration/Connections/OracleConnectionTest.php
+++ b/tests/Configuration/Connections/OracleConnectionTest.php
@@ -34,7 +34,8 @@ class OracleConnectionTest extends PHPUnit_Framework_TestCase
             'password'    => 'password',
             'charset'     => 'charset',
             'port'        => 'port',
-            'prefix'      => 'prefix'
+            'prefix'      => 'prefix',
+            'defaultTableOptions' => [],
         ]);
 
         $this->assertEquals('oci8', $resolved['driver']);
@@ -45,6 +46,7 @@ class OracleConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('charset', $resolved['charset']);
         $this->assertEquals('port', $resolved['port']);
         $this->assertEquals('prefix', $resolved['prefix']);
+        $this->assertCount(0, $resolved['defaultTableOptions']);
     }
 
     protected function tearDown()

--- a/tests/Configuration/Connections/OracleConnectionTest.php
+++ b/tests/Configuration/Connections/OracleConnectionTest.php
@@ -27,14 +27,14 @@ class OracleConnectionTest extends PHPUnit_Framework_TestCase
     public function test_can_resolve()
     {
         $resolved = $this->connection->resolve([
-            'driver'      => 'oci8',
-            'host'        => 'host',
-            'database'    => 'database',
-            'username'    => 'username',
-            'password'    => 'password',
-            'charset'     => 'charset',
-            'port'        => 'port',
-            'prefix'      => 'prefix',
+            'driver'              => 'oci8',
+            'host'                => 'host',
+            'database'            => 'database',
+            'username'            => 'username',
+            'password'            => 'password',
+            'charset'             => 'charset',
+            'port'                => 'port',
+            'prefix'              => 'prefix',
             'defaultTableOptions' => [],
         ]);
 

--- a/tests/Configuration/Connections/PgsqlConnectionTest.php
+++ b/tests/Configuration/Connections/PgsqlConnectionTest.php
@@ -27,15 +27,15 @@ class PgsqlConnectionTest extends PHPUnit_Framework_TestCase
     public function test_can_resolve()
     {
         $resolved = $this->connection->resolve([
-            'driver'   => 'pdo_pgsql',
-            'host'     => 'host',
-            'database' => 'database',
-            'username' => 'username',
-            'password' => 'password',
-            'charset'  => 'charset',
-            'port'     => 'port',
-            'prefix'   => 'prefix',
-            'sslmode'  => 'sslmode',
+            'driver'              => 'pdo_pgsql',
+            'host'                => 'host',
+            'database'            => 'database',
+            'username'            => 'username',
+            'password'            => 'password',
+            'charset'             => 'charset',
+            'port'                => 'port',
+            'prefix'              => 'prefix',
+            'sslmode'             => 'sslmode',
             'defaultTableOptions' => [],
         ]);
 

--- a/tests/Configuration/Connections/PgsqlConnectionTest.php
+++ b/tests/Configuration/Connections/PgsqlConnectionTest.php
@@ -35,7 +35,8 @@ class PgsqlConnectionTest extends PHPUnit_Framework_TestCase
             'charset'  => 'charset',
             'port'     => 'port',
             'prefix'   => 'prefix',
-            'sslmode'  => 'sslmode'
+            'sslmode'  => 'sslmode',
+            'defaultTableOptions' => [],
         ]);
 
         $this->assertEquals('pdo_pgsql', $resolved['driver']);
@@ -47,6 +48,7 @@ class PgsqlConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('port', $resolved['port']);
         $this->assertEquals('sslmode', $resolved['sslmode']);
         $this->assertEquals('prefix', $resolved['prefix']);
+        $this->assertCount(0, $resolved['defaultTableOptions']);
     }
 
     protected function tearDown()

--- a/tests/Configuration/Connections/SqliteConnectionTest.php
+++ b/tests/Configuration/Connections/SqliteConnectionTest.php
@@ -32,6 +32,7 @@ class SqliteConnectionTest extends PHPUnit_Framework_TestCase
             'username' => 'username',
             'password' => 'password',
             'prefix'   => 'prefix',
+            'defaultTableOptions' => [],
         ]);
 
         $this->assertEquals('pdo_sqlite', $resolved['driver']);
@@ -40,6 +41,7 @@ class SqliteConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('prefix', $resolved['prefix']);
         $this->assertFalse($resolved['memory']);
         $this->assertEquals('path', $resolved['path']);
+        $this->assertCount(0, $resolved['defaultTableOptions']);
     }
 
     public function test_can_resolve_with_in_memory_database()

--- a/tests/Configuration/Connections/SqliteConnectionTest.php
+++ b/tests/Configuration/Connections/SqliteConnectionTest.php
@@ -27,11 +27,11 @@ class SqliteConnectionTest extends PHPUnit_Framework_TestCase
     public function test_can_resolve()
     {
         $resolved = $this->connection->resolve([
-            'driver'   => 'pdo_sqlite',
-            'database' => 'path',
-            'username' => 'username',
-            'password' => 'password',
-            'prefix'   => 'prefix',
+            'driver'              => 'pdo_sqlite',
+            'database'            => 'path',
+            'username'            => 'username',
+            'password'            => 'password',
+            'prefix'              => 'prefix',
             'defaultTableOptions' => [],
         ]);
 

--- a/tests/Configuration/Connections/SqlsrvConnectionTest.php
+++ b/tests/Configuration/Connections/SqlsrvConnectionTest.php
@@ -27,14 +27,14 @@ class SqlsrvConnectionTest extends PHPUnit_Framework_TestCase
     public function test_can_resolve()
     {
         $resolved = $this->connection->resolve([
-            'driver'   => 'pdo_sqlsrv',
-            'host'     => 'host',
-            'database' => 'database',
-            'username' => 'username',
-            'password' => 'password',
-            'port'     => 'port',
-            'prefix'   => 'prefix',
-            'charset'  => 'charset',
+            'driver'              => 'pdo_sqlsrv',
+            'host'                => 'host',
+            'database'            => 'database',
+            'username'            => 'username',
+            'password'            => 'password',
+            'port'                => 'port',
+            'prefix'              => 'prefix',
+            'charset'             => 'charset',
             'defaultTableOptions' => [],
         ]);
 

--- a/tests/Configuration/Connections/SqlsrvConnectionTest.php
+++ b/tests/Configuration/Connections/SqlsrvConnectionTest.php
@@ -34,7 +34,8 @@ class SqlsrvConnectionTest extends PHPUnit_Framework_TestCase
             'password' => 'password',
             'port'     => 'port',
             'prefix'   => 'prefix',
-            'charset'  => 'charset'
+            'charset'  => 'charset',
+            'defaultTableOptions' => [],
         ]);
 
         $this->assertEquals('pdo_sqlsrv', $resolved['driver']);
@@ -45,6 +46,7 @@ class SqlsrvConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('port', $resolved['port']);
         $this->assertEquals('prefix', $resolved['prefix']);
         $this->assertEquals('charset', $resolved['charset']);
+        $this->assertCount(0, $resolved['defaultTableOptions']);
     }
 
     protected function tearDown()


### PR DESCRIPTION
(Original: #224)

### Changes proposed in this pull request:
- Supporting `defaultTableOptions` in configration resolving. This is supported by doctrine and enables developers to set a default collation on all tables.

I was unable to make all tests work, as they seem to have broken on 1.2.