### PR TITLE
[FEATURE] Add ability to provide different folders for Entity Factories via doctrine.php config

### DIFF
--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -204,5 +204,21 @@ return [
      */
     'notifications'              => [
         'channel' => 'database'
+    ],
+
+    /*
+     |--------------------------------------------------------------------------
+     | Doctrine Entity Factories
+     |--------------------------------------------------------------------------
+     |
+     |  You can add custom folders with your factories, for instance, if you have
+     |  modular system and each module contains its own factories.
+     |  If no folders are specify, the default one will be used ('database/factories' in project root)
+     |
+     */
+    'factories' => [
+        'folders' => [
+            'Modules/User/Database/Factory'
+        ]
     ]
 ];

--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -218,7 +218,8 @@ return [
      */
     'factories' => [
         'folders' => [
-            'Modules/User/Database/Factory'
+            // 'Modules/User/Database/Factory',
+            // 'Modules/Features/Database/Factory'
         ]
     ]
 ];

--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -218,8 +218,8 @@ return [
      */
     'factories' => [
         'folders' => [
-            // 'Modules/User/Database/Factory',
-            // 'Modules/Features/Database/Factory'
+            database_path('factories'),
+            // base_path('Modules/User/Database/Factory'),
         ]
     ]
 ];

--- a/src/DoctrineServiceProvider.php
+++ b/src/DoctrineServiceProvider.php
@@ -283,7 +283,7 @@ class DoctrineServiceProvider extends ServiceProvider
             return EntityFactory::construct(
                 $app->make(FakerGenerator::class),
                 $app->make('registry'),
-                database_path('factories')
+                $app->make('config')->get('doctrine.factories.folders', null)
             );
         });
     }

--- a/src/Testing/Factory.php
+++ b/src/Testing/Factory.php
@@ -55,7 +55,7 @@ class Factory implements ArrayAccess
 
         $factory = new static($faker, $registry);
 
-        foreach ( (array)$pathToFactories as $factoryDir) {
+        foreach ((array) $pathToFactories as $factoryDir) {
             if (is_dir($factoryDir)) {
                 foreach (Finder::create()->files()->in($factoryDir) as $file) {
                     require $file->getRealPath();

--- a/src/Testing/Factory.php
+++ b/src/Testing/Factory.php
@@ -55,7 +55,7 @@ class Factory implements ArrayAccess
 
         $factory = new static($faker, $registry);
 
-        foreach ((array)$pathToFactories as $factoryDir) {
+        foreach ( (array)$pathToFactories as $factoryDir) {
             if (is_dir($factoryDir)) {
                 foreach (Finder::create()->files()->in($factoryDir) as $file) {
                     require $file->getRealPath();

--- a/src/Testing/Factory.php
+++ b/src/Testing/Factory.php
@@ -45,7 +45,7 @@ class Factory implements ArrayAccess
      *
      * @param \Faker\Generator $faker
      * @param ManagerRegistry  $registry
-     * @param string|null      $pathToFactories
+     * @param array|string|null      $pathToFactories
      *
      * @return static
      */
@@ -55,9 +55,11 @@ class Factory implements ArrayAccess
 
         $factory = new static($faker, $registry);
 
-        if (is_dir($pathToFactories)) {
-            foreach (Finder::create()->files()->in($pathToFactories) as $file) {
-                require $file->getRealPath();
+        foreach ((array)$pathToFactories as $factoryDir) {
+            if (is_dir($factoryDir)) {
+                foreach (Finder::create()->files()->in($factoryDir) as $file) {
+                    require $file->getRealPath();
+                }
             }
         }
 

--- a/src/Testing/Factory.php
+++ b/src/Testing/Factory.php
@@ -43,9 +43,9 @@ class Factory implements ArrayAccess
     /**
      * Create a new factory container.
      *
-     * @param \Faker\Generator $faker
-     * @param ManagerRegistry  $registry
-     * @param array|string|null      $pathToFactories
+     * @param \Faker\Generator  $faker
+     * @param ManagerRegistry   $registry
+     * @param array|string|null $pathToFactories
      *
      * @return static
      */


### PR DESCRIPTION
### Changes proposed in this pull request:
- Using doctrine.php config file user can use his own Entity Factory folders. 

_Reason:_
I was stuck with a problem: I'm developing an application using modular approach. Each module has its own entities and its own factories for them. But I couldn't run the factories because of hard-coded folder that leads to 'database/factories' in the project root.

Thanks!