### PR TITLE
[FIX] Don't use  for all as there is no join

### DIFF
--- a/src/Pagination/PaginatesFromParams.php
+++ b/src/Pagination/PaginatesFromParams.php
@@ -16,7 +16,7 @@ trait PaginatesFromParams
     {
         $query = $this->createQueryBuilder('o')->getQuery();
 
-        return $this->paginate($query, $perPage, $page);
+        return $this->paginate($query, $perPage, $page, false);
     }
 
     /**

--- a/src/Pagination/PaginatesFromRequest.php
+++ b/src/Pagination/PaginatesFromRequest.php
@@ -16,7 +16,7 @@ trait PaginatesFromRequest
     {
         $query = $this->createQueryBuilder('o')->getQuery();
 
-        return $this->paginate($query, $perPage, $pageName);
+        return $this->paginate($query, $perPage, $pageName, false);
     }
 
     /**


### PR DESCRIPTION
### Changes proposed in this pull request:
- Set `$fetchJoinCollection` to false for `paginateAll` queries as we are sure that they won't do any join, this will reduce the number of queries by 1.