### PR TITLE
[FIX] Convert seconds to milliseconds

### DIFF
--- a/src/Loggers/Clockwork/DoctrineDataSource.php
+++ b/src/Loggers/Clockwork/DoctrineDataSource.php
@@ -60,7 +60,7 @@ class DoctrineDataSource extends DataSource
         foreach ($this->logger->queries as $query) {
             $queries[] = [
                 'query'      => $this->formatter->format($query['sql'], $query['params']),
-                'duration'   => $query['executionMS'],
+                'duration'   => $query['executionMS'] * 1000,
                 'connection' => $this->connection
             ];
         }

--- a/tests/Loggers/Clockwork/DoctrineDataSourceTest.php
+++ b/tests/Loggers/Clockwork/DoctrineDataSourceTest.php
@@ -23,7 +23,7 @@ class DoctrineDataSourceTest extends PHPUnit_Framework_TestCase
             [
                 'sql'         => 'SELECT * FROM table WHERE condition = ?',
                 'params'      => ['value'],
-                'executionMS' => 1
+                'executionMS' => 0.001
             ]
         ];
 


### PR DESCRIPTION
### Changes proposed in this pull request:
- See [comment](https://github.com/doctrine/dbal/pull/2739#issuecomment-306880407) `executionMS` is actually seconds not milliseconds.