### PR TITLE
[FIX] Throw an exception if exist: rule refers to an invalid entity type

### DIFF
--- a/src/Validation/DoctrinePresenceVerifier.php
+++ b/src/Validation/DoctrinePresenceVerifier.php
@@ -5,6 +5,7 @@ namespace LaravelDoctrine\ORM\Validation;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\QueryBuilder;
 use Illuminate\Validation\PresenceVerifierInterface;
+use InvalidArgumentException;
 
 class DoctrinePresenceVerifier implements PresenceVerifierInterface
 {
@@ -90,9 +91,6 @@ class DoctrinePresenceVerifier implements PresenceVerifierInterface
     protected function select($collection)
     {
         $em = $this->getEntityManager($collection);
-        if ($em === null) {
-            throw new \InvalidArgumentException("[$collection] is not a valid Doctrine type.");
-        }
 
         $builder = $em->createQueryBuilder();
 
@@ -124,7 +122,13 @@ class DoctrinePresenceVerifier implements PresenceVerifierInterface
             return $this->registry->getManager($this->connection);
         }
 
-        return $this->registry->getManagerForClass($entity);
+        $em = $this->registry->getManagerForClass($entity);
+
+        if ($em === null) {
+            throw new InvalidArgumentException(sprintf("No Entity Manager could be found for [%s].", $entity));
+        }
+
+        return $em;
     }
 
     /**

--- a/src/Validation/DoctrinePresenceVerifier.php
+++ b/src/Validation/DoctrinePresenceVerifier.php
@@ -93,7 +93,7 @@ class DoctrinePresenceVerifier implements PresenceVerifierInterface
         if ($em === null) {
             throw new \InvalidArgumentException("[$collection] is not a valid Doctrine type.");
         }
-        
+
         $builder = $em->createQueryBuilder();
 
         $builder->select('count(e)')->from($collection, 'e');

--- a/src/Validation/DoctrinePresenceVerifier.php
+++ b/src/Validation/DoctrinePresenceVerifier.php
@@ -89,7 +89,10 @@ class DoctrinePresenceVerifier implements PresenceVerifierInterface
      */
     protected function select($collection)
     {
-        $em      = $this->getEntityManager($collection);
+        $em = $this->getEntityManager($collection);
+        if(is_null($em)) {
+            throw new \InvalidArgumentException($collection . ' is not a valid Doctrine entity type');
+        }
         $builder = $em->createQueryBuilder();
 
         $builder->select('count(e)')->from($collection, 'e');

--- a/src/Validation/DoctrinePresenceVerifier.php
+++ b/src/Validation/DoctrinePresenceVerifier.php
@@ -90,9 +90,10 @@ class DoctrinePresenceVerifier implements PresenceVerifierInterface
     protected function select($collection)
     {
         $em = $this->getEntityManager($collection);
-        if(is_null($em)) {
-            throw new \InvalidArgumentException($collection . ' is not a valid Doctrine entity type');
+        if ($em === null) {
+            throw new \InvalidArgumentException("[$collection] is not a valid Doctrine type.");
         }
+        
         $builder = $em->createQueryBuilder();
 
         $builder->select('count(e)')->from($collection, 'e');

--- a/src/Validation/DoctrinePresenceVerifier.php
+++ b/src/Validation/DoctrinePresenceVerifier.php
@@ -90,8 +90,7 @@ class DoctrinePresenceVerifier implements PresenceVerifierInterface
      */
     protected function select($collection)
     {
-        $em = $this->getEntityManager($collection);
-
+        $em      = $this->getEntityManager($collection);
         $builder = $em->createQueryBuilder();
 
         $builder->select('count(e)')->from($collection, 'e');

--- a/tests/Validation/DoctrinePresenceVerifierTest.php
+++ b/tests/Validation/DoctrinePresenceVerifierTest.php
@@ -123,6 +123,17 @@ class DoctrinePresenceVerifierTest extends PHPUnit_Framework_TestCase
         ]);
     }
 
+    public function test_counting_invalid_entity_throws_exception()
+    {
+        $this->registry->shouldReceive('getManagerForClass')
+                       ->with(CountableEntityMock::class)
+                       ->andReturn(null);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->verifier->getCount(CountableEntityMock::class, 'email', 'test@email.com');
+    }
+
     protected function defaultGetCountMocks()
     {
         $this->registry->shouldReceive('getManagerForClass')

--- a/tests/Validation/DoctrinePresenceVerifierTest.php
+++ b/tests/Validation/DoctrinePresenceVerifierTest.php
@@ -126,10 +126,11 @@ class DoctrinePresenceVerifierTest extends PHPUnit_Framework_TestCase
     public function test_counting_invalid_entity_throws_exception()
     {
         $this->registry->shouldReceive('getManagerForClass')
-                       ->with(CountableEntityMock::class)
-                       ->andReturn(null);
+            ->with(CountableEntityMock::class)
+            ->andReturn(null);
 
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No Entity Manager could be found for [CountableEntityMock].');
 
         $this->verifier->getCount(CountableEntityMock::class, 'email', 'test@email.com');
     }


### PR DESCRIPTION
### Current behavior
When using the `exists:` rule with `DoctrinePresenceVerifier` on a non-mapped class, the following error is thrown: `Call to a member function createQueryBuilder() on null`
### Proposed behavior
Throw an easy to understand `InvalidArgumentException`: `\App\User is not a valid Doctrine entity type`