### PR TITLE
Allow symfony/serializer:^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "illuminate/support": "5.4.*",
     "illuminate/validation": "5.4.*",
     "illuminate/view": "5.4.*",
-    "symfony/serializer": "^2.7"
+    "symfony/serializer": "^2.7 | ^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.0",


### PR DESCRIPTION
Allow optional use of ^3.0 for symfony/serializer. Tests pass with this change.

Please prefix your pull request with one of the following: [FIX] [FEATURE].

### Changes proposed in this pull request:
-
-
-