### PR TITLE
[FIX] Ignore tests folder from git exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/tests export-ignore


### PR DESCRIPTION
This prevents composer from downloading the tests suite when projects depend on this.