### PR TITLE
[FEATURE] Add hydrator registration to EntityManagerFactory

### DIFF
--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -132,6 +132,14 @@ return [
     'custom_string_functions'    => [],
     /*
     |--------------------------------------------------------------------------
+    | Register custom hydrators
+    |--------------------------------------------------------------------------
+    */
+    'custom_hydration_modes'     => [
+        // e.g. 'hydrationModeName' => MyHydrator::class,
+    ],
+    /*
+    |--------------------------------------------------------------------------
     | Enable query logging with laravel file logging,
     | debugbar, clockwork or an own implementation.
     | Setting it to false, will disable logging

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -328,7 +328,7 @@ class EntityManagerFactory
      */
     protected function setCustomHydrationModes(Configuration $configuration)
     {
-        $hydratorConfig = $this->config->get('doctrine.custom_hydration_modes');
+        $hydratorConfig = $this->config->get('doctrine.custom_hydration_modes', []);
         foreach ($hydratorConfig as $hydrationModeName => $customHydratorClass) {
             $configuration->addCustomHydrationMode($hydrationModeName, $customHydratorClass);
         }

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -117,7 +117,7 @@ class EntityManagerFactory
 
         $this->setNamingStrategy($settings, $configuration);
         $this->setCustomFunctions($configuration);
-        $this->setCustomHydrationModes($configuration);        
+        $this->setCustomHydrationModes($configuration);
         $this->setCacheSettings($configuration);
         $this->configureProxies($settings, $configuration);
         $this->setCustomMappingDriverChain($settings, $configuration);
@@ -328,9 +328,9 @@ class EntityManagerFactory
      */
     protected function setCustomHydrationModes(Configuration $configuration)
     {
-        $hydratorConfig = $this->config->get('doctrine.custom_hydration_modes'); 
+        $hydratorConfig = $this->config->get('doctrine.custom_hydration_modes');
         foreach ($hydratorConfig as $hydrationModeName => $customHydratorClass) {
-            $configuration->addCustomHydrationMode($hydrationModeName, $customHydratorClass);    
+            $configuration->addCustomHydrationMode($hydrationModeName, $customHydratorClass);
         }
     }
 

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -117,6 +117,7 @@ class EntityManagerFactory
 
         $this->setNamingStrategy($settings, $configuration);
         $this->setCustomFunctions($configuration);
+        $this->setCustomHydrationModes($configuration);        
         $this->setCacheSettings($configuration);
         $this->configureProxies($settings, $configuration);
         $this->setCustomMappingDriverChain($settings, $configuration);
@@ -320,6 +321,17 @@ class EntityManagerFactory
         $configuration->setCustomDatetimeFunctions($this->config->get('doctrine.custom_datetime_functions'));
         $configuration->setCustomNumericFunctions($this->config->get('doctrine.custom_numeric_functions'));
         $configuration->setCustomStringFunctions($this->config->get('doctrine.custom_string_functions'));
+    }
+
+    /**
+     * @param Configuration $configuration
+     */
+    protected function setCustomHydrationModes(Configuration $configuration)
+    {
+        $hydratorConfig = $this->config->get('doctrine.custom_hydration_modes'); 
+        foreach ($hydratorConfig as $hydrationModeName => $customHydratorClass) {
+            $configuration->addCustomHydrationMode($hydrationModeName, $customHydratorClass);    
+        }
     }
 
     /**

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -532,6 +532,12 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
                      ->andReturn(['string']);
 
         $strictCallCountChecking ? $expectation->once() : $expectation->never();
+
+        $expectation = $this->config->shouldReceive('get')
+                     ->with('doctrine.custom_hydration_modes')
+                     ->andReturn([]);
+
+        $strictCallCountChecking ? $expectation->once() : $expectation->never();
     }
 
     protected function mockCache()

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -534,7 +534,7 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
         $strictCallCountChecking ? $expectation->once() : $expectation->never();
 
         $expectation = $this->config->shouldReceive('get')
-                     ->with('doctrine.custom_hydration_modes')
+                     ->with('doctrine.custom_hydration_modes', [])
                      ->andReturn([]);
 
         $strictCallCountChecking ? $expectation->once() : $expectation->never();


### PR DESCRIPTION
* Enables an easy way to register custom Doctrine hydrators
* Add `custom_hydration_modes` entry to `doctrine` config
* Add `setCustomHydrationModes` method to EntityManagerFactory
* Implements #256