### PR TITLE
[FIX] Update LaravelNamingStrategy.php

### DIFF
--- a/src/Configuration/LaravelNamingStrategy.php
+++ b/src/Configuration/LaravelNamingStrategy.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Str;
 class LaravelNamingStrategy implements NamingStrategy
 {
     /**
-     * @type Str
+     * @var Str
      */
     protected $str;
 


### PR DESCRIPTION
/** @type Str */ is not valid docstring and doctrine annotations try to use it as annotation with JMS Serializer and Doctrine Annotation and throw Exception on this. Probably that should be changed to /** @var Str */

Please prefix your pull request with one of the following: [FIX] [FEATURE].

### Changes proposed in this pull request:
-
-
-