### PR TITLE
[FEATURE] Add support for driver options

### DIFF
--- a/src/Configuration/Connections/MysqlConnection.php
+++ b/src/Configuration/Connections/MysqlConnection.php
@@ -22,6 +22,7 @@ class MysqlConnection extends Connection
             'unix_socket'           => array_get($settings, 'unix_socket'),
             'prefix'                => array_get($settings, 'prefix'),
             'defaultTableOptions'   => array_get($settings, 'defaultTableOptions', []),
+            'driverOptions'         => array_get($settings, 'driverOptions', []),
         ];
     }
 }

--- a/tests/Configuration/Connections/MysqlConnectionTest.php
+++ b/tests/Configuration/Connections/MysqlConnectionTest.php
@@ -37,6 +37,7 @@ class MysqlConnectionTest extends PHPUnit_Framework_TestCase
             'unix_socket'         => 'unix_socket',
             'prefix'              => 'prefix',
             'defaultTableOptions' => [],
+            'driverOptions'       => [],
         ]);
 
         $this->assertEquals('pdo_mysql', $resolved['driver']);
@@ -49,6 +50,7 @@ class MysqlConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('unix_socket', $resolved['unix_socket']);
         $this->assertEquals('prefix', $resolved['prefix']);
         $this->assertCount(0, $resolved['defaultTableOptions']);
+        $this->assertCount(0, $resolved['driverOptions']);
     }
 
     protected function tearDown()


### PR DESCRIPTION
### Changes proposed in this pull request:
- Supporting driverOptions in configration resolving. (http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#mysqli)

These changes are compatible with branches 1.2 and 1.3

I need these changes to add option: 
`'driverOptions' => [\PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8"]`