### PR TITLE
FIX - Oracle Connection parameters for SERVICE_NAME connection

### DIFF
--- a/src/Configuration/Connections/OracleConnection.php
+++ b/src/Configuration/Connections/OracleConnection.php
@@ -15,6 +15,8 @@ class OracleConnection extends Connection
             'driver'                => 'oci8',
             'host'                  => array_get($settings, 'host'),
             'dbname'                => array_get($settings, 'database'),
+            'servicename'           => array_get($settings, 'service_name'),
+            'service'               => array_get($settings, 'service'),
             'user'                  => array_get($settings, 'username'),
             'password'              => array_get($settings, 'password'),
             'charset'               => array_get($settings, 'charset'),


### PR DESCRIPTION
Please prefix your pull request with one of the following: [FIX] [FEATURE].

### Changes proposed in this pull request:
- Oracle Connection parameters for SERVICE_NAME connection. By the way those parameters is expected in oci8, but OracleConnection don't predicted.
