### PR TITLE
[FIX] Remove  @ORM\Entity in Superclass

### DIFF
--- a/src/Notifications/Notification.php
+++ b/src/Notifications/Notification.php
@@ -5,7 +5,6 @@ namespace LaravelDoctrine\ORM\Notifications;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * @ORM\Entity
  * @ORM\MappedSuperclass
  */
 class Notification


### PR DESCRIPTION
`@ORM\Entity` сaused an error:
Column not found: 1054 Unknown column 'n0_.id' in 'field list'

Please prefix your pull request with one of the following: [FIX] [FEATURE].

### Changes proposed in this pull request:
- Remove @ORM\Entity in Superclass