### PR TITLE
[FIXish] Travis fixes

### DIFF
--- a/src/Types/Json.php
+++ b/src/Types/Json.php
@@ -36,7 +36,11 @@ class Json extends JsonArrayType
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        return $value === null ? null : parent::convertToPHPValue($value, $platform);
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return parent::convertToPHPValue($value, $platform);
     }
 
     /**

--- a/tests/Configuration/Cache/IlluminateCacheAdapterTest.php
+++ b/tests/Configuration/Cache/IlluminateCacheAdapterTest.php
@@ -28,10 +28,10 @@ class IlluminateCacheAdapterTest extends PHPUnit_Framework_TestCase
     {
         $this->repository->shouldReceive('get')
                          ->with('DoctrineNamespaceCacheKey[]')
-                         ->once()->andReturn('cacheKey');
+                         ->once()->andReturn(1);
 
         $this->repository->shouldReceive('get')
-                         ->with('[1][cacheKey]')
+                         ->with('[1][1]')
                          ->once()->andReturn('fetched');
 
         $this->assertEquals('fetched', $this->cache->fetch(1));
@@ -41,14 +41,14 @@ class IlluminateCacheAdapterTest extends PHPUnit_Framework_TestCase
     {
         $this->repository->shouldReceive('get')
                          ->with('DoctrineNamespaceCacheKey[]')
-                         ->once()->andReturn('cacheKey');
+                         ->once()->andReturn(1);
 
         $this->repository->shouldReceive('get')
-                         ->with('[1][cacheKey]')
+                         ->with('[1][1]')
                          ->once()->andReturn('fetched1');
 
         $this->repository->shouldReceive('get')
-                         ->with('[2][cacheKey]')
+                         ->with('[2][1]')
                          ->once()->andReturn('fetched2');
 
         $result = $this->cache->fetchMultiple([1, 2]);
@@ -61,10 +61,10 @@ class IlluminateCacheAdapterTest extends PHPUnit_Framework_TestCase
     {
         $this->repository->shouldReceive('get')
                          ->with('DoctrineNamespaceCacheKey[]')
-                         ->once()->andReturn('cacheKey');
+                         ->once()->andReturn(1);
 
         $this->repository->shouldReceive('has')
-                         ->with('[1][cacheKey]')
+                         ->with('[1][1]')
                          ->once()->andReturn(true);
 
         $this->assertTrue($this->cache->contains(1));
@@ -74,10 +74,10 @@ class IlluminateCacheAdapterTest extends PHPUnit_Framework_TestCase
     {
         $this->repository->shouldReceive('get')
                          ->with('DoctrineNamespaceCacheKey[]')
-                         ->once()->andReturn('cacheKey');
+                         ->once()->andReturn(1);
 
         $this->repository->shouldReceive('put')
-                         ->with('[1][cacheKey]', 'data', 1)
+                         ->with('[1][1]', 'data', 1)
                          ->once()->andReturn(true);
 
         $this->assertTrue($this->cache->save(1, 'data', 60));
@@ -87,10 +87,10 @@ class IlluminateCacheAdapterTest extends PHPUnit_Framework_TestCase
     {
         $this->repository->shouldReceive('get')
                          ->with('DoctrineNamespaceCacheKey[]')
-                         ->once()->andReturn('cacheKey');
+                         ->once()->andReturn(1);
 
         $this->repository->shouldReceive('forget')
-                         ->with('[1][cacheKey]')
+                         ->with('[1][1]')
                          ->once()->andReturn(true);
 
         $this->assertTrue($this->cache->delete(1));
@@ -103,7 +103,7 @@ class IlluminateCacheAdapterTest extends PHPUnit_Framework_TestCase
                          ->once()->andReturn(1);
 
         $this->repository->shouldReceive('forever')
-                         ->with("DoctrineNamespaceCacheKey[]", 2)
+                         ->with('DoctrineNamespaceCacheKey[]', 2)
                          ->once()->andReturn(true);
 
         $this->assertTrue($this->cache->deleteAll());
@@ -124,10 +124,10 @@ class IlluminateCacheAdapterTest extends PHPUnit_Framework_TestCase
 
         $this->repository->shouldReceive('get')
                          ->with('DoctrineNamespaceCacheKey[namespace]')
-                         ->once()->andReturn('cacheKey');
+                         ->once()->andReturn(1);
 
         $this->repository->shouldReceive('get')
-                         ->with('namespace[1][cacheKey]')
+                         ->with('namespace[1][1]')
                          ->once()->andReturn('fetched');
 
         $this->assertEquals('fetched', $this->cache->fetch(1));

--- a/tests/Types/JsonTypeTest.php
+++ b/tests/Types/JsonTypeTest.php
@@ -33,9 +33,9 @@ class JsonTypeTest extends PHPUnit_Framework_TestCase
         $this->assertNull($this->type->convertToPHPValue(null, $this->platform));
     }
 
-    public function test_it_returns_empty_array_when_database_value_is_empty()
+    public function test_it_returns_null_when_database_value_is_empty()
     {
-        $this->assertEquals([], $this->type->convertToPHPValue('', $this->platform));
+        $this->assertEquals(null, $this->type->convertToPHPValue('', $this->platform));
     }
 
     public function test_it_returns_array_when_database_value_is_json()


### PR DESCRIPTION
- The Cache adapter was using strings on a mock method that was supposed to be returning an int.
- The JsonType is not compatible with doctrine/dbal 2.6. Current test fetches the "json" type from Doctrine, so I assumed it was testing compatibility, not only this implementation. This will break backwards compat tho.