### PR TITLE
Add support for using persistent connections!

### DIFF
--- a/src/Configuration/Connections/OracleConnection.php
+++ b/src/Configuration/Connections/OracleConnection.php
@@ -23,6 +23,7 @@ class OracleConnection extends Connection
             'port'                  => array_get($settings, 'port'),
             'prefix'                => array_get($settings, 'prefix'),
             'defaultTableOptions'   => array_get($settings, 'defaultTableOptions', []),
+            'persistent'            => array_get($settings, 'persistent'),
         ];
     }
 }


### PR DESCRIPTION
The oci_pconnect function reuses sessions, allowing even greater scalability. The non-persistent
connection functions create and destroy new sessions each time they are used, allowing less sharing at the
cost of reduced performance.
Overall, after a brief warm-up period for the pool, DRCP allows reduced connection times in addition to the
reuse benefits of pooling.
The constructor of the Doctrine \ DBAL \ Driver \ OCI8 \ OCI8Connection class has a $ persistent parameter, but we are currently unable to pass true to it. This change allows the developer to add this option in their configuration file, for example:
database.php
