### PR TITLE
Add support for using persistent connections

### DIFF
--- a/tests/Configuration/Connections/OracleConnectionTest.php
+++ b/tests/Configuration/Connections/OracleConnectionTest.php
@@ -36,6 +36,7 @@ class OracleConnectionTest extends PHPUnit_Framework_TestCase
             'port'                => 'port',
             'prefix'              => 'prefix',
             'defaultTableOptions' => [],
+            'persistent'          => 'persistent',
         ]);
 
         $this->assertEquals('oci8', $resolved['driver']);
@@ -47,6 +48,7 @@ class OracleConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('port', $resolved['port']);
         $this->assertEquals('prefix', $resolved['prefix']);
         $this->assertCount(0, $resolved['defaultTableOptions']);
+        $this->assertEquals('persistent', $resolved['persistent']);
     }
 
     protected function tearDown()


### PR DESCRIPTION
The oci_pconnect function reuses sessions, allowing even greater scalability. The non-persistent
connection functions create and destroy new sessions each time they are used, allowing less sharing at the
cost of reduced performance.
Overall, after a brief warm-up period for the pool, DRCP allows reduced connection times in addition to the
reuse benefits of pooling.
The constructor of the Doctrine \ DBAL \ Driver \ OCI8 \ OCI8Connection class has a $ persistent parameter, but we are currently unable to pass true to it. This change allows the developer to add this option in their configuration file, for example:
database.php

Please prefix your pull request with one of the following: [FIX] [FEATURE].

### Changes proposed in this pull request:
-
-
-