### PR TITLE
[PROPOSAL] Allow for first forward slash in entity FQN for validation rules

### DIFF
--- a/src/Validation/DoctrinePresenceVerifier.php
+++ b/src/Validation/DoctrinePresenceVerifier.php
@@ -120,6 +120,10 @@ class DoctrinePresenceVerifier implements PresenceVerifierInterface
         if (!is_null($this->connection)) {
             return $this->registry->getManager($this->connection);
         }
+        
+        if(substr($entity, 0, 1) === '\\') {
+        	$entity = substr($entity, 1);
+        }
 
         $em = $this->registry->getManagerForClass($entity);
 

--- a/src/Validation/DoctrinePresenceVerifier.php
+++ b/src/Validation/DoctrinePresenceVerifier.php
@@ -120,7 +120,7 @@ class DoctrinePresenceVerifier implements PresenceVerifierInterface
         if (!is_null($this->connection)) {
             return $this->registry->getManager($this->connection);
         }
-        
+
         if (substr($entity, 0, 1) === '\\') {
             $entity = substr($entity, 1);
         }

--- a/src/Validation/DoctrinePresenceVerifier.php
+++ b/src/Validation/DoctrinePresenceVerifier.php
@@ -121,8 +121,8 @@ class DoctrinePresenceVerifier implements PresenceVerifierInterface
             return $this->registry->getManager($this->connection);
         }
         
-        if(substr($entity, 0, 1) === '\\') {
-        	$entity = substr($entity, 1);
+        if (substr($entity, 0, 1) === '\\') {
+            $entity = substr($entity, 1);
         }
 
         $em = $this->registry->getManagerForClass($entity);


### PR DESCRIPTION
This PR will normalize FQN names for exists and unique rules.

As of now, we are getting errors, if we use exists rule like this: `'exists:\App\Entities\User'` instead of `'exists:App\Entities\User'`. Even though both cases should be valid FQNs.

Thanks, Jakub
