### PR TITLE
[FEATURE] Persist new entities when calling make

### DIFF
--- a/src/Testing/FactoryBuilder.php
+++ b/src/Testing/FactoryBuilder.php
@@ -169,10 +169,11 @@ class FactoryBuilder
 
         $definition = call_user_func($this->definitions[$this->class][$this->name], $this->faker, $attributes);
         $definition = $this->applyStates($definition, $attributes);
-        $manager = $this->registry->getManagerForClass($this->class);
+        $manager    = $this->registry->getManagerForClass($this->class);
 
         if ($definition instanceof $this->class) {
             $manager->persist($definition);
+
             return $definition;
         }
 
@@ -237,7 +238,7 @@ class FactoryBuilder
     protected function applyStates(array $definition, array $attributes = [])
     {
         foreach ($this->activeStates as $state) {
-            if (!isset($this->states[ $state ])) {
+            if (!isset($this->states[$state])) {
                 throw new InvalidArgumentException("Unable to locate [{$state}] state for [{$this->class}].");
             }
 
@@ -254,12 +255,12 @@ class FactoryBuilder
      * Get the state attributes.
      *
      * @param  string $state
-     * @param  array $attributes
+     * @param  array  $attributes
      * @return array
      */
     protected function stateAttributes($state, array $attributes)
     {
-        $stateAttributes = $this->states[ $state ];
+        $stateAttributes = $this->states[$state];
 
         if (!is_callable($stateAttributes)) {
             return $stateAttributes;

--- a/tests/Testing/FactoryBuilderTest.php
+++ b/tests/Testing/FactoryBuilderTest.php
@@ -101,6 +101,9 @@ class FactoryBuilderTest extends MockeryTestCase
         $instance = $this->getFactoryBuilder()->make();
 
         $this->assertInstanceOf(EntityStub::class, $instance);
+
+        $this->entityManager->shouldHaveReceived('persist')->with($instance)->once();
+        $this->entityManager->shouldNotHaveReceived('flush');
     }
 
     public function test_it_creates_instances_of_the_class()


### PR DESCRIPTION
This implements solution one of my proposal #266  

### Changes proposed in this pull request:
- Entities created through `make()` are persisted (but not flushed).

This allows for much faster setup for tests with lot of different entities by calling flush at the end, see proposal for more details.