### PR TITLE
[FEATURE] Add getModel() function to DoctrineUserProvider

### DIFF
--- a/src/Auth/DoctrineUserProvider.php
+++ b/src/Auth/DoctrineUserProvider.php
@@ -140,7 +140,7 @@ class DoctrineUserProvider implements UserProvider
      */
     public function getModel()
     {
-    	return $this->entity;
+        return $this->entity;
     }
 }
 

--- a/src/Auth/DoctrineUserProvider.php
+++ b/src/Auth/DoctrineUserProvider.php
@@ -133,4 +133,14 @@ class DoctrineUserProvider implements UserProvider
 
         return $refEntity->newInstanceWithoutConstructor();
     }
+
+    /**
+     * Returns entity namespace.
+     * @return string
+     */
+    public function getModel()
+    {
+    	return $this->entity;
+    }
 }
+

--- a/src/Auth/DoctrineUserProvider.php
+++ b/src/Auth/DoctrineUserProvider.php
@@ -143,4 +143,3 @@ class DoctrineUserProvider implements UserProvider
         return $this->entity;
     }
 }
-


### PR DESCRIPTION
### Changes proposed in this pull request:
- implemented `getModel()` method in `DoctrineUserProvider.php` to make provider  consistent with `EloquentUserProvider` 

I found a problem using `tymondesigns/jwt-auth` with `laravel-doctrine/orm` where JWT is referring to `getModel()` function in https://github.com/tymondesigns/jwt-auth/blob/develop/src/JWTGuard.php#L77 in user provider to get namespace, but it doesn't exist in `DoctrineUserProvider`. To make it consistent and substitutional with `EloquentUserProvider` https://github.com/laravel/framework/blob/5.5/src/Illuminate/Auth/EloquentUserProvider.php#L170 my suggestion is to create `getModel()` function.