### PR TITLE
[FEATURE] Persist entities returned from a closure

### DIFF
--- a/src/Testing/FactoryBuilder.php
+++ b/src/Testing/FactoryBuilder.php
@@ -210,9 +210,26 @@ class FactoryBuilder
     protected function callClosureAttributes(array $attributes)
     {
         return array_map(function ($attribute) use ($attributes) {
-            return $attribute instanceof \Closure ?
-                $attribute($attributes) :
-                $attribute;
+            if ($attribute instanceof \Closure) {
+                $entity = $attribute($attributes);
+                if (is_object($entity)) {
+                    $this->registry
+                        ->getManagerForClass(get_class($entity))
+                        ->persist($entity);
+                } elseif (is_array($entity)) {
+                    foreach ($entity as $e) {
+                        if (is_object($e)) {
+                            $this->registry
+                                ->getManagerForClass(get_class($e))
+                                ->persist($e);
+                        }
+                    }
+                }
+
+                return $entity;
+            }
+
+            return $attribute;
         }, $attributes);
     }
 

--- a/tests/Testing/FactoryBuilderTest.php
+++ b/tests/Testing/FactoryBuilderTest.php
@@ -155,7 +155,6 @@ class FactoryBuilderTest extends MockeryTestCase
 
         $this->assertSame($madeInstance, $instance->others[0]);
 
-
         $this->entityManager->shouldHaveReceived('persist')->with($madeInstance)->once();
     }
 

--- a/tests/Testing/FactoryBuilderTest.php
+++ b/tests/Testing/FactoryBuilderTest.php
@@ -135,6 +135,30 @@ class FactoryBuilderTest extends MockeryTestCase
         $this->assertEquals(['Foo'], $instance->others);
     }
 
+    public function test_it_should_persist_entities_returned_by_a_closure()
+    {
+        $madeInstance = new EntityStub();
+
+        $instance = $this->getFactoryBuilder([
+            EntityStub::class => [
+                'default' => function () use ($madeInstance) {
+                    return [
+                        'id'     => 1,
+                        'name'   => 'a name',
+                        'others' => function() use ($madeInstance) {
+                            return [$madeInstance];
+                        },
+                    ];
+                }
+            ]
+        ])->create();
+
+        $this->assertSame($madeInstance, $instance->others[0]);
+
+
+        $this->entityManager->shouldHaveReceived('persist')->with($madeInstance)->once();
+    }
+
     public function test_it_handles_states()
     {
         $states = [

--- a/tests/Testing/FactoryBuilderTest.php
+++ b/tests/Testing/FactoryBuilderTest.php
@@ -145,7 +145,7 @@ class FactoryBuilderTest extends MockeryTestCase
                     return [
                         'id'     => 1,
                         'name'   => 'a name',
-                        'others' => function() use ($madeInstance) {
+                        'others' => function () use ($madeInstance) {
                             return [$madeInstance];
                         },
                     ];


### PR DESCRIPTION
This implements solution 3 of my proposal #266  and replaces pull request #279

### Changes proposed in this pull request:
- Entities created through a clojure are persisted to the manager

This allows for much faster setup for tests with lot of different entities by calling flush at the end, see proposal for more details.

Example:
```php
$factory->defineAs(App\User::class, function(Faker\Generator $faker) {
    return [
        'name' => $faker->name,
        'role' => function() {
          return entity(App\Role::class)->make(); // Before you had to call create here or enable cascade persist
       }
    ];
});
```

