### PR TITLE
[FIX] Optimize UserProvider if just one Object Manager

### DIFF
--- a/src/IlluminateRegistry.php
+++ b/src/IlluminateRegistry.php
@@ -336,7 +336,13 @@ final class IlluminateRegistry implements ManagerRegistry
             $class = $proxyClass->getParentClass()->getName();
         }
 
-        foreach ($this->getManagerNames() as $name) {
+        $managerNames = $this->getManagerNames();
+
+        if (count($managerNames) === 1) {
+            return $this->getManager(reset($managerNames));
+        }
+
+        foreach ($managerNames as $name) {
             $manager = $this->getManager($name);
 
             if (!$manager->getMetadataFactory()->isTransient($class)) {


### PR DESCRIPTION
I was doing some profiling with xdebug, and noticed that the UserProvider was spending **30%** of the entire request inside `getAllMetadata`. This led me up to this method that will verify that `$class` (our User class) is actually managed by the ObjectManager returned from `getManagerNames`.

Since we only have one EntityManager, I thought that this wasnt necessary, so just doing an early return instead. 

Our testsuite is still OK with this change, but Iam not familiar enough with doctrine to know if this is OK..