### PR TITLE
Fix DefaultQueryCache not knowing that we put anything to the store

### DIFF
--- a/src/Configuration/Cache/IlluminateCacheAdapter.php
+++ b/src/Configuration/Cache/IlluminateCacheAdapter.php
@@ -51,7 +51,9 @@ class IlluminateCacheAdapter extends CacheProvider
     protected function doSave($id, $data, $lifeTime = false)
     {
         if (!$lifeTime) {
-            return $this->cache->forever($id, $data);
+            $this->cache->forever($id, $data);
+
+            return true;
         }
 
         // Laravel cache system accept expire times in minutes
@@ -59,7 +61,9 @@ class IlluminateCacheAdapter extends CacheProvider
         // before passing it to Laravel cache repository
         $lifeTimeMinutes = $lifeTime / 60;
 
-        return $this->cache->put($id, $data, $lifeTimeMinutes);
+        $this->cache->put($id, $data, $lifeTimeMinutes);
+
+        return true;
     }
 
     /**

--- a/src/Configuration/Cache/IlluminateCacheAdapter.php
+++ b/src/Configuration/Cache/IlluminateCacheAdapter.php
@@ -51,7 +51,7 @@ class IlluminateCacheAdapter extends CacheProvider
      * @param string $id       The cache id.
      * @param string $data     The cache entry/data.
      * @param int    $lifeTime The lifetime. If != 0, sets a specific lifetime for this
-     *                           cache entry (0 => infinite lifeTime).
+     *                         cache entry (0 => infinite lifeTime).
      *
      * @return bool TRUE always, because the cache repository have void return
      */

--- a/src/Configuration/Cache/IlluminateCacheAdapter.php
+++ b/src/Configuration/Cache/IlluminateCacheAdapter.php
@@ -46,7 +46,14 @@ class IlluminateCacheAdapter extends CacheProvider
     }
 
     /**
-     * {@inheritdoc}
+     * Puts data into the cache.
+     *
+     * @param string $id       The cache id.
+     * @param string $data     The cache entry/data.
+     * @param int    $lifeTime The lifetime. If != 0, sets a specific lifetime for this
+     *                           cache entry (0 => infinite lifeTime).
+     *
+     * @return bool TRUE always, because the cache repository have void return
      */
     protected function doSave($id, $data, $lifeTime = false)
     {

--- a/tests/Configuration/Cache/IlluminateCacheAdapterTest.php
+++ b/tests/Configuration/Cache/IlluminateCacheAdapterTest.php
@@ -78,7 +78,7 @@ class IlluminateCacheAdapterTest extends PHPUnit_Framework_TestCase
 
         $this->repository->shouldReceive('put')
                          ->with('[1][1]', 'data', 1)
-                         ->once()->andReturn(true);
+                         ->once()->andReturn(null);
 
         $this->assertTrue($this->cache->save(1, 'data', 60));
     }


### PR DESCRIPTION
There is a mismatch between the two cache interfaces:

- Doctrine\Common\Cache\Cache::save: bool
- Illuminate\Contracts\Cache\Repository::put(): void

See the laravel implementation here [Illuminate\Cache\Repository](https://github.com/illuminate/cache/blob/master/Repository.php#L188). (called via $this->cache->put())

I noticed this while stepping into DefaultQueryCache::put() when trying to cache the result of a query. [See the call here](https://github.com/doctrine/doctrine2/blob/07b397f3419e37f4ac0bf1d0a55572af7cb9d575/lib/Doctrine/ORM/Cache/DefaultQueryCache.php#L282).