### PR TITLE
[FIX] Stop execution of command after successful drop

### DIFF
--- a/src/Console/SchemaDropCommand.php
+++ b/src/Console/SchemaDropCommand.php
@@ -60,6 +60,8 @@ class SchemaDropCommand extends Command
                     }
 
                     $this->info('Database schema dropped successfully!');
+                    
+                    return 0;
                 }
 
                 if ($this->option('full')) {

--- a/src/Console/SchemaDropCommand.php
+++ b/src/Console/SchemaDropCommand.php
@@ -60,7 +60,7 @@ class SchemaDropCommand extends Command
                     }
 
                     $this->info('Database schema dropped successfully!');
-                    
+
                     return 0;
                 }
 


### PR DESCRIPTION
This fixes issue where you would get output like this:

```
[..]
Database schema dropped successfully!
Nothing to drop. The database is empty!
```