### PR TITLE
[FIX] Use cache for annotation reader

### DIFF
--- a/src/Configuration/MetaData/Annotations.php
+++ b/src/Configuration/MetaData/Annotations.php
@@ -2,10 +2,21 @@
 
 namespace LaravelDoctrine\ORM\Configuration\MetaData;
 
-use Doctrine\ORM\Configuration;
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\Common\Annotations\CachedReader;
+use Doctrine\Common\Annotations\SimpleAnnotationReader;
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Cache;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 
 class Annotations extends MetaData
 {
+    /**
+     * @var Cache
+     */
+    protected $cache;
+
     /**
      * @param array $settings
      *
@@ -13,9 +24,44 @@ class Annotations extends MetaData
      */
     public function resolve(array $settings = [])
     {
-        return (new Configuration())->newDefaultAnnotationDriver(
-            array_get($settings, 'paths', []),
-            array_get($settings, 'simple', false)
-        );
+        $useSimpleAnnotationReader = array_get($settings, 'simple', false);
+        $paths                     = array_get($settings, 'paths', []);
+
+        $annotationDriverFilename = (new \ReflectionClass(AnnotationDriver::class))->getFileName();
+        AnnotationRegistry::registerFile(dirname($annotationDriverFilename) . '/DoctrineAnnotations.php');
+
+        if ($useSimpleAnnotationReader) {
+            $reader = new SimpleAnnotationReader();
+            $reader->addNamespace('Doctrine\ORM\Mapping');
+            $cachedReader = new CachedReader($reader, $this->getCache());
+
+            return new AnnotationDriver($cachedReader, (array) $paths);
+        }
+
+        return new AnnotationDriver(new CachedReader(new AnnotationReader(), $this->getCache()), (array) $paths);
+    }
+
+    /**
+     * @return Cache
+     */
+    public function getCache()
+    {
+        if ($this->cache === null) {
+            $this->cache = new ArrayCache();
+        }
+
+        return $this->cache;
+    }
+
+    /**
+     * @param Cache $cache
+     *
+     * @return $this
+     */
+    public function setCache(Cache $cache)
+    {
+        $this->cache = $cache;
+
+        return $this;
     }
 }

--- a/tests/Configuration/MetaData/AnnotationsTest.php
+++ b/tests/Configuration/MetaData/AnnotationsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use LaravelDoctrine\ORM\Configuration\MetaData\Annotations;
@@ -17,8 +18,22 @@ class AnnotationsTest extends PHPUnit_Framework_TestCase
         $this->meta = new Annotations();
     }
 
+    public function test_can_resolve_simple_with_cache()
+    {
+        /** @var AnnotationDriver $resolved */
+        $resolved = $this->meta->resolve([
+            'paths'   => ['entities'],
+            'dev'     => true,
+            'proxies' => ['path' => 'path'],
+            'simple'  => true
+        ]);
+
+        $this->assertAnnotationDriver($resolved);
+    }
+
     public function test_can_resolve()
     {
+        /** @var AnnotationDriver $resolved */
         $resolved = $this->meta->resolve([
             'paths'   => ['entities'],
             'dev'     => true,
@@ -26,8 +41,17 @@ class AnnotationsTest extends PHPUnit_Framework_TestCase
             'simple'  => false
         ]);
 
+        $this->assertAnnotationDriver($resolved);
+    }
+
+    /**
+     * @param AnnotationDriver $resolved
+     */
+    protected function assertAnnotationDriver($resolved)
+    {
         $this->assertInstanceOf(MappingDriver::class, $resolved);
         $this->assertInstanceOf(AnnotationDriver::class, $resolved);
+        $this->assertInstanceOf(CachedReader::class, $resolved->getReader());
     }
 
     protected function tearDown()


### PR DESCRIPTION
Annotation reader using `ArrayCache` that is performance killer.
http://docs.doctrine-project.org/projects/doctrine-common/en/latest/reference/annotations.html#setup-and-configuration

- Implemented usage of default cache for annotation reader.
