### PR TITLE
[FEATURE] Support configurable wrapperClass in MasterSlaveConnection

### DIFF
--- a/src/Configuration/Connections/MasterSlaveConnection.php
+++ b/src/Configuration/Connections/MasterSlaveConnection.php
@@ -41,7 +41,7 @@ class MasterSlaveConnection extends Connection
         $driver = $this->resolvedBaseSettings['driver'];
 
         return [
-            'wrapperClass' => MasterSlaveDoctrineWrapper::class,
+            'wrapperClass' => $settings['wrapperClass'] ?? MasterSlaveDoctrineWrapper::class,
             'driver'       => $driver,
             'master'       => $this->getConnectionData(isset($settings['write']) ? $settings['write'] : [], $driver),
             'slaves'       => $this->getSlavesConfig($settings['read'], $driver),


### PR DESCRIPTION
The hardcoded Doctrine classname cannot be overridden.

### Changes proposed in this pull request:
- support Doctrine's wrapperClass configuration option in the MasterSlaveConnection wrapper