### PR TITLE
[FIX] Depend on AbstractQuery instead of Query

### DIFF
--- a/src/Pagination/PaginatesFromParams.php
+++ b/src/Pagination/PaginatesFromParams.php
@@ -2,7 +2,7 @@
 
 namespace LaravelDoctrine\ORM\Pagination;
 
-use Doctrine\ORM\Query;
+use Doctrine\ORM\AbstractQuery;
 
 trait PaginatesFromParams
 {
@@ -20,14 +20,14 @@ trait PaginatesFromParams
     }
 
     /**
-     * @param Query $query
-     * @param int   $perPage
-     * @param int   $page
-     * @param bool  $fetchJoinCollection
+     * @param AbstractQuery $query
+     * @param int           $perPage
+     * @param int           $page
+     * @param bool          $fetchJoinCollection
      *
      * @return \Illuminate\Pagination\LengthAwarePaginator
      */
-    public function paginate(Query $query, $perPage, $page = 1, $fetchJoinCollection = true)
+    public function paginate(AbstractQuery $query, $perPage, $page = 1, $fetchJoinCollection = true)
     {
         return PaginatorAdapter::fromParams(
             $query,

--- a/src/Pagination/PaginatesFromRequest.php
+++ b/src/Pagination/PaginatesFromRequest.php
@@ -2,7 +2,7 @@
 
 namespace LaravelDoctrine\ORM\Pagination;
 
-use Doctrine\ORM\Query;
+use Doctrine\ORM\AbstractQuery;
 
 trait PaginatesFromRequest
 {
@@ -20,14 +20,14 @@ trait PaginatesFromRequest
     }
 
     /**
-     * @param Query  $query
-     * @param int    $perPage
-     * @param bool   $fetchJoinCollection
-     * @param string $pageName
+     * @param AbstractQuery $query
+     * @param int           $perPage
+     * @param bool          $fetchJoinCollection
+     * @param string        $pageName
      *
      * @return \Illuminate\Pagination\LengthAwarePaginator
      */
-    public function paginate(Query $query, $perPage, $pageName = 'page', $fetchJoinCollection = true)
+    public function paginate(AbstractQuery $query, $perPage, $pageName = 'page', $fetchJoinCollection = true)
     {
         return PaginatorAdapter::fromRequest(
             $query,


### PR DESCRIPTION
### Changes proposed in this pull request:
- fix two method parameters to require AbstractQuery instead of Query (which is final) so it can be used with mocks for testing