### PR TITLE
[FEATURE] Allow Lumen Publishing

### DIFF
--- a/src/DoctrineServiceProvider.php
+++ b/src/DoctrineServiceProvider.php
@@ -49,11 +49,9 @@ class DoctrineServiceProvider extends ServiceProvider
         $this->extendAuthManager();
         $this->extendNotificationChannel();
 
-        if (!$this->isLumen()) {
-            $this->publishes([
-                $this->getConfigPath() => config_path('doctrine.php'),
-            ], 'config');
-        }
+        $this->publishes([
+            $this->getConfigPath() => config_path('doctrine.php'),
+        ], 'config');
 
         $this->ensureValidatorIsUsable();
     }


### PR DESCRIPTION
### Changes proposed in this pull request:

- Allows for publishing config files in lumen.

Even though lumen doesn't provide vendor publishing by default, it's easily enabled by just adding in the `Illuminate\Foundation\Console\VendorPublishCommand`. However, since you have the `isLumen` check, no laravel-doctrine files get published.