### PR TITLE
[FIX] Fix intermittent unit test failures

### DIFF
--- a/tests/Testing/FactoryBuilderTest.php
+++ b/tests/Testing/FactoryBuilderTest.php
@@ -156,7 +156,7 @@ class FactoryBuilderTest extends MockeryTestCase
     {
         $states = [
             'withState' => function () {
-                return ['name' => 'stateful'];
+                return ['id' => 2, 'name' => 'stateful'];
             },
             'other' => function () {
                 return ['id' => 3];
@@ -166,7 +166,7 @@ class FactoryBuilderTest extends MockeryTestCase
         $instance = $this->getFactoryBuilder([], $states)->states('withState')->make();
 
         $this->assertEquals('stateful', $instance->name);
-        $this->assertNotEquals(3, $instance->id);
+        $this->assertEquals(2, $instance->id);
     }
 }
 


### PR DESCRIPTION
Sometimes the ID of the first "state" happens to be 3. Instead of
testing what it is not, specify an ID manually and test that the
ID equals that.