### PR TITLE
[FIX] Change DebugBar widget name to doctrine.

### DIFF
--- a/src/Loggers/Debugbar/DoctrineCollector.php
+++ b/src/Loggers/Debugbar/DoctrineCollector.php
@@ -26,13 +26,13 @@ class DoctrineCollector extends DebugbarDoctrineCollector
     public function getWidgets()
     {
         return [
-            "queries" => [
+            "doctrine" => [
                 "icon"    => "arrow-right",
                 "widget"  => "PhpDebugBar.Widgets.SQLQueriesWidget",
                 "map"     => "doctrine",
                 "default" => "[]"
             ],
-            "queries:badge" => [
+            "doctrine:badge" => [
                 "map"     => "doctrine.nb_statements",
                 "default" => 0
             ]


### PR DESCRIPTION
Switching 'queries' with 'doctrine'.  This will show both queries
 widget and doctrine widget.  Discussed in #305.

### Changes proposed in this pull request:
-  This changes the current behavior of the DebugBar widget.  The queries and doctrine widgets now display separately.