### PR TITLE
[FIX] Default to false when setting the "dev" configuration value

### DIFF
--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -22,7 +22,7 @@ return [
     */
     'managers'                   => [
         'default' => [
-            'dev'           => env('APP_DEBUG'),
+            'dev'           => env('APP_DEBUG', false),
             'meta'          => env('DOCTRINE_METADATA', 'annotations'),
             'connection'    => env('DB_CONNECTION', 'mysql'),
             'namespaces'    => [],


### PR DESCRIPTION
The value gets passed down to methods requiring a boolean so null won't do the trick.

Fixes errors such as this one:

```
TypeError: Argument 1 passed to Doctrine\ORM\Tools\Setup::createCacheConfiguration() must be of the type boolean, null given, called in /vagrant/api/vendor/doctrine/orm/lib/Doctrine/ORM/Tools/Setup.php on line 126
```

I noticed this error when running our unit tests without a `.env` file (we only set specific variables in `phpunit.xml`, but not nearly all of them). This seems like a reasonable default since the value must be a boolean.