### PR TITLE
[FIX] Validation:Adding Additional Where Clauses

### DIFF
--- a/src/Validation/DoctrinePresenceVerifier.php
+++ b/src/Validation/DoctrinePresenceVerifier.php
@@ -105,8 +105,17 @@ class DoctrinePresenceVerifier implements PresenceVerifierInterface
     protected function queryExtraConditions(array $extra, QueryBuilder $builder)
     {
         foreach ($extra as $key => $extraValue) {
-            $builder->andWhere("e.{$key} = :" . $this->prepareParam($key));
-            $builder->setParameter($this->prepareParam($key), $extraValue);
+            if ($extraValue === 'NULL') {
+                $builder->andWhere("e.{$key} IS NULL");
+            } elseif ($extraValue === 'NOT_NULL') {
+                $builder->andWhere("e.{$key} IS NOT NULL");
+            } elseif (\Illuminate\Support\Str::startsWith($extraValue, '!')) {
+                $builder->andWhere("e.{$key} != :" . $this->prepareParam($key));
+                $builder->setParameter($this->prepareParam($key), mb_substr($extraValue, 1));
+            } else {
+                $builder->andWhere("e.{$key} = :" . $this->prepareParam($key));
+                $builder->setParameter($this->prepareParam($key), $extraValue);
+            }
         }
     }
 

--- a/tests/Validation/DoctrinePresenceVerifierTest.php
+++ b/tests/Validation/DoctrinePresenceVerifierTest.php
@@ -88,12 +88,63 @@ class DoctrinePresenceVerifierTest extends PHPUnit_Framework_TestCase
         $this->builder->shouldReceive('andWhere')
                       ->once()->with('e.condition2 = :condition2');
 
+        $this->builder->shouldReceive('andWhere')
+                      ->once()->with('e.condition3 != :condition3');
+
+        $this->builder->shouldReceive('setParameter')->once()->with('condition1', 'value1');
+        $this->builder->shouldReceive('setParameter')->once()->with('condition2', 'value2');
+        $this->builder->shouldReceive('setParameter')->once()->with('condition3', 'value3');
+
+        $this->verifier->getCount(CountableEntityMock::class, 'email', 'test@email.com', null, null, [
+            'condition1' => 'value1',
+            'condition2' => 'value2',
+            'condition3' => '!value3'
+        ]);
+    }
+
+    public function test_can_get_count_with_extra_conditions_with_null()
+    {
+        $this->defaultGetCountMocks();
+
+        $this->builder->shouldReceive('andWhere')
+                      ->once()->with('e.condition1 = :condition1');
+
+        $this->builder->shouldReceive('andWhere')
+                      ->once()->with('e.condition2 = :condition2');
+
+        $this->builder->shouldReceive('andWhere')
+                      ->once()->with('e.condition3 IS NULL');
+
         $this->builder->shouldReceive('setParameter')->once()->with('condition1', 'value1');
         $this->builder->shouldReceive('setParameter')->once()->with('condition2', 'value2');
 
         $this->verifier->getCount(CountableEntityMock::class, 'email', 'test@email.com', null, null, [
             'condition1' => 'value1',
-            'condition2' => 'value2'
+            'condition2' => 'value2',
+            'condition3' => 'NULL'
+        ]);
+    }
+
+    public function test_can_get_count_with_extra_conditions_with_not_null()
+    {
+        $this->defaultGetCountMocks();
+
+        $this->builder->shouldReceive('andWhere')
+                      ->once()->with('e.condition1 = :condition1');
+
+        $this->builder->shouldReceive('andWhere')
+                      ->once()->with('e.condition2 = :condition2');
+
+        $this->builder->shouldReceive('andWhere')
+                      ->once()->with('e.condition3 IS NOT NULL');
+
+        $this->builder->shouldReceive('setParameter')->once()->with('condition1', 'value1');
+        $this->builder->shouldReceive('setParameter')->once()->with('condition2', 'value2');
+
+        $this->verifier->getCount(CountableEntityMock::class, 'email', 'test@email.com', null, null, [
+            'condition1' => 'value1',
+            'condition2' => 'value2',
+            'condition3' => 'NOT_NULL'
         ]);
     }
 


### PR DESCRIPTION
Please prefix your pull request with one of the following: [FIX] [FEATURE].

### Changes proposed in this pull request:
Code fix is similar to method at:
Illuminate\Validation\DatabasePresenceVerifier:addWhere()

What doesn’t work:
https://www.laraveldoctrine.org/docs/1.3/orm/validation
'email' => 'unique:users,email_address,NULL,id,account_id,NULL’
'email' => 'unique:users,email_address,NULL,id,account_id,NOT_NULL’

This will create query like the following:
account_id = ‘NULL’

Instead of:
account_id IS NULL