### PR TITLE
[FEATURE] Added closeManager() and purgeManager() to IlluminateRegistry

### DIFF
--- a/src/IlluminateRegistry.php
+++ b/src/IlluminateRegistry.php
@@ -246,21 +246,10 @@ final class IlluminateRegistry implements ManagerRegistry
     }
 
     /**
-     * Resets a named object manager.
-     * This method is useful when an object manager has been closed
-     * because of a rollbacked transaction AND when you think that
-     * it makes sense to get a new one to replace the closed one.
-     * Be warned that you will get a brand new object manager as
-     * the existing one is not useable anymore. This means that any
-     * other object with a dependency on this object manager will
-     * hold an obsolete reference. You can inject the registry instead
-     * to avoid this problem.
-     *
+     * Close an existing object manager.
      * @param string|null $name The object manager name (null for the default one).
-     *
-     * @return \Doctrine\Common\Persistence\ObjectManager
      */
-    public function resetManager($name = null)
+    public function closeManager($name = null)
     {
         $name = $name ?: $this->getDefaultManagerName();
 
@@ -280,7 +269,43 @@ final class IlluminateRegistry implements ManagerRegistry
 
         unset($this->managersMap[$name]);
         unset($this->connectionsMap[$name]);
+    }
 
+    /**
+     * Purge a named object manager.
+     * 
+     * This method can be used if you wish to close an object manager manually, without opening a new one.
+     * This can be useful if you wish to open a new manager later (but maybe with different settings).
+     *
+     * @param string|null $name The object manager name (null for the default one).
+     */
+    public function purgeManager($name = null)
+    {
+        $name = $name ?: $this->getDefaultManagerName();
+        $this->closeManager($name);
+
+        unset($this->managers[$name]);
+        unset($this->connections[$name]);
+    }
+
+    /**
+     * Resets a named object manager.
+     * This method is useful when an object manager has been closed
+     * because of a rollbacked transaction AND when you think that
+     * it makes sense to get a new one to replace the closed one.
+     * Be warned that you will get a brand new object manager as
+     * the existing one is not useable anymore. This means that any
+     * other object with a dependency on this object manager will
+     * hold an obsolete reference. You can inject the registry instead
+     * to avoid this problem.
+     *
+     * @param string|null $name The object manager name (null for the default one).
+     *
+     * @return \Doctrine\Common\Persistence\ObjectManager
+     */
+    public function resetManager($name = null)
+    {
+        $this->closeManager($name);
         return $this->getManager($name);
     }
 

--- a/tests/IlluminateRegistryTest.php
+++ b/tests/IlluminateRegistryTest.php
@@ -271,6 +271,20 @@ class IlluminateRegistryTest extends PHPUnit_Framework_TestCase
         $this->assertContains('manager2', $managers);
     }
 
+    public function test_can_purge_default_manager()
+    {
+        $this->container->shouldReceive('singleton');
+        $this->registry->addManager('default');
+
+        $this->container->shouldReceive('forgetInstance', 'doctrine.managers.default');
+        $this->container->shouldReceive('make')
+            ->with('doctrine.managers.default')
+            ->andReturn(m::mock(\Doctrine\Common\Persistence\ObjectManager::class));
+
+        $this->registry->purgeManager();
+        $this->assertFalse($this->registry->managerExists('default'));
+    }
+
     public function test_can_reset_default_manager()
     {
         $this->container->shouldReceive('singleton');
@@ -287,6 +301,20 @@ class IlluminateRegistryTest extends PHPUnit_Framework_TestCase
         $this->assertSame($manager, $this->registry->getManager());
     }
 
+    public function test_can_purge_custom_manager()
+    {
+        $this->container->shouldReceive('singleton');
+        $this->registry->addManager('custom');
+
+        $this->container->shouldReceive('forgetInstance', 'doctrine.managers.custom');
+        $this->container->shouldReceive('make')
+            ->with('doctrine.managers.custom')
+            ->andReturn(m::mock(\Doctrine\Common\Persistence\ObjectManager::class));
+
+        $this->registry->purgeManager();
+        $this->assertFalse($this->registry->managerExists('custom'));
+    }
+
     public function test_can_reset_custom_manager()
     {
         $this->container->shouldReceive('singleton');
@@ -301,6 +329,16 @@ class IlluminateRegistryTest extends PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(\Doctrine\Common\Persistence\ObjectManager::class, $manager);
         $this->assertSame($manager, $this->registry->getManager('custom'));
+    }
+
+    public function test_cannot_purge_non_existing_managers()
+    {
+        $this->setExpectedException(
+            InvalidArgumentException::class,
+            'Doctrine Manager named "non-existing" does not exist.'
+        );
+
+        $this->registry->purgeManager('non-existing');
     }
 
     public function test_cannot_reset_non_existing_managers()


### PR DESCRIPTION
The changes I made in this pull request would allow a user to explicitly close or purge an existing object manager.
With the close function you should be able to get a new instance of it again later (using _getManager()_) and with purge you would have to explicitly add a new one (using _addManager()_).

In my usecase, I have the situation where we use different databases in the same connection that is determined by logic in the code. To be able to switch from one database to another I want to be able to explicitly close the object manager and get it back later, but with this time, using a different dynamic configuration.

Sadly, the only function available was the _resetManager()_ function, which immediately gives me a new manager and wouldn't reliably change the connection.