### PR TITLE
 [FIX]  ReplaceQueryParams throws ErrorException

### DIFF
--- a/src/Loggers/Formatters/ReplaceQueryParams.php
+++ b/src/Loggers/Formatters/ReplaceQueryParams.php
@@ -4,6 +4,8 @@ namespace LaravelDoctrine\ORM\Loggers\Formatters;
 
 use DateTime;
 use Exception;
+use function is_array;
+use function json_decode;
 
 class ReplaceQueryParams implements QueryFormatter
 {
@@ -42,7 +44,7 @@ class ReplaceQueryParams implements QueryFormatter
                 }
             }
         } elseif (is_array($param)) {
-            if (count($param) !== count($param, COUNT_RECURSIVE)) {
+            if ($this->isNestedArray($param)) {
                 $param = json_encode($param, JSON_UNESCAPED_UNICODE);
             } else {
                 $param = implode(
@@ -62,5 +64,19 @@ class ReplaceQueryParams implements QueryFormatter
         }
 
         return '"' . (string) $param . '"';
+    }
+
+    /**
+     * @param array $array
+     * @return bool
+     */
+    private function isNestedArray(array $array) {
+        foreach ($array as $key => $value) {
+            if (is_array($value)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Loggers/Formatters/ReplaceQueryParamsTest.php
+++ b/tests/Loggers/Formatters/ReplaceQueryParamsTest.php
@@ -95,6 +95,23 @@ class ReplaceQueryParamsTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function test_can_replace_nested_array_param2()
+    {
+        $sql    = 'INSERT INTO foo (column1) VALUES (?)';
+        $params = [
+            1 => [
+                'id'     => 20,
+                'foo'    => 'bar',
+                'nested' => []
+            ]
+        ];
+
+        $this->assertEquals(
+            'INSERT INTO foo (column1) VALUES ("{"id":20,"foo":"bar","nested":[]}")',
+            $this->formatter->format($sql, $params)
+        );
+    }
+
     protected function tearDown()
     {
         m::close();


### PR DESCRIPTION
Fixes #253. 

---

Note that in the tests we are expecting:
```
VALUES ("{"id":20,"foo":"bar","nested":[]}")
```
While it should be
```
VALUES ("{\"id\":20,\"foo\":\"bar\",\"nested\":[]}")'
```

Should be considered to open an issue about this.
