### PR TITLE
[Fix] Logger to work with custom types

### DIFF
--- a/src/Loggers/Clockwork/DoctrineDataSource.php
+++ b/src/Loggers/Clockwork/DoctrineDataSource.php
@@ -4,6 +4,7 @@ namespace LaravelDoctrine\ORM\Loggers\Clockwork;
 
 use Clockwork\DataSource\DataSource;
 use Clockwork\Request\Request;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Logging\SQLLogger;
 use LaravelDoctrine\ORM\Loggers\Formatters\FormatQueryKeywords;
 use LaravelDoctrine\ORM\Loggers\Formatters\QueryFormatter;
@@ -17,7 +18,7 @@ class DoctrineDataSource extends DataSource
     protected $logger;
 
     /**
-     * @var
+     * @var Connection
      */
     protected $connection;
 
@@ -30,7 +31,7 @@ class DoctrineDataSource extends DataSource
      * @param SQLLogger $logger
      * @param           $connection
      */
-    public function __construct(SQLLogger $logger, $connection)
+    public function __construct(SQLLogger $logger, Connection $connection)
     {
         $this->logger     = $logger;
         $this->connection = $connection;
@@ -59,9 +60,9 @@ class DoctrineDataSource extends DataSource
         $queries = [];
         foreach ($this->logger->queries as $query) {
             $queries[] = [
-                'query'      => $this->formatter->format($query['sql'], $query['params']),
+                'query'      => $this->formatter->format($this->connection->getDatabasePlatform(), $query['sql'], $query['params']),
                 'duration'   => $query['executionMS'] * 1000,
-                'connection' => $this->connection
+                'connection' => $this->connection->getDriver()->getName()
             ];
         }
 

--- a/src/Loggers/ClockworkLogger.php
+++ b/src/Loggers/ClockworkLogger.php
@@ -34,7 +34,7 @@ class ClockworkLogger implements Logger
         $this->clockwork->addDataSource(
             new DoctrineDataSource(
                 $debugStack,
-                $em->getConnection()->getDriver()->getName()
+                $em->getConnection()
             )
         );
     }

--- a/src/Loggers/File/DoctrineFileLogger.php
+++ b/src/Loggers/File/DoctrineFileLogger.php
@@ -2,6 +2,7 @@
 
 namespace LaravelDoctrine\ORM\Loggers\File;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Logging\SQLLogger;
 use LaravelDoctrine\ORM\Loggers\Formatters\FormatQueryKeywords;
 use LaravelDoctrine\ORM\Loggers\Formatters\ReplaceQueryParams;
@@ -30,12 +31,19 @@ class DoctrineFileLogger implements SQLLogger
     protected $query;
 
     /**
-     * @param Log $logger
+     * @var Connection
      */
-    public function __construct(Log $logger)
+    protected $connection;
+
+    /**
+     * @param Log $logger
+     * @param Connection $connection
+     */
+    public function __construct(Log $logger, Connection $connection)
     {
         $this->logger    = $logger;
         $this->formatter = new FormatQueryKeywords(new ReplaceQueryParams);
+        $this->connection = $connection;
     }
 
     /**
@@ -50,7 +58,7 @@ class DoctrineFileLogger implements SQLLogger
     public function startQuery($sql, array $params = null, array $types = null)
     {
         $this->start = microtime(true);
-        $this->query = $this->formatter->format($sql, $params);
+        $this->query = $this->formatter->format($this->connection->getDatabasePlatform(), $sql, $params, $types);
     }
 
     /**

--- a/src/Loggers/File/DoctrineFileLogger.php
+++ b/src/Loggers/File/DoctrineFileLogger.php
@@ -36,13 +36,13 @@ class DoctrineFileLogger implements SQLLogger
     protected $connection;
 
     /**
-     * @param Log $logger
+     * @param Log        $logger
      * @param Connection $connection
      */
     public function __construct(Log $logger, Connection $connection)
     {
-        $this->logger    = $logger;
-        $this->formatter = new FormatQueryKeywords(new ReplaceQueryParams);
+        $this->logger     = $logger;
+        $this->formatter  = new FormatQueryKeywords(new ReplaceQueryParams);
         $this->connection = $connection;
     }
 

--- a/src/Loggers/FileLogger.php
+++ b/src/Loggers/FileLogger.php
@@ -28,7 +28,7 @@ class FileLogger implements Logger
      */
     public function register(EntityManagerInterface $em, Configuration $configuration)
     {
-        $logger = new DoctrineFileLogger($this->logger);
+        $logger = new DoctrineFileLogger($this->logger, $em->getConnection());
         $configuration->setSQLLogger($logger);
     }
 }

--- a/src/Loggers/Formatters/FormatQueryKeywords.php
+++ b/src/Loggers/Formatters/FormatQueryKeywords.php
@@ -2,6 +2,8 @@
 
 namespace LaravelDoctrine\ORM\Loggers\Formatters;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
 class FormatQueryKeywords implements QueryFormatter
 {
     /**
@@ -44,14 +46,16 @@ class FormatQueryKeywords implements QueryFormatter
     }
 
     /**
+     * @param AbstractPlatform
      * @param string     $sql
      * @param array|null $params
+     * @param array|null $types
      *
      * @return string
      */
-    public function format($sql, array $params = null)
+    public function format($platform, $sql, array $params = null, array $types = null)
     {
-        $sql = $this->formatter->format($sql, $params);
+        $sql = $this->formatter->format($platform, $sql, $params, $types);
 
         return preg_replace_callback('/\b' . implode('\b|\b', $this->keywords) . '\b/i', function ($match) {
             return strtoupper($match[0]);

--- a/src/Loggers/Formatters/QueryFormatter.php
+++ b/src/Loggers/Formatters/QueryFormatter.php
@@ -8,9 +8,9 @@ interface QueryFormatter
 {
     /**
      * @param AbstractPlatform $platform
-     * @param string     $sql
-     * @param array|null $params
-     * @param array|null $types
+     * @param string           $sql
+     * @param array|null       $params
+     * @param array|null       $types
      *
      * @return string
      */

--- a/src/Loggers/Formatters/QueryFormatter.php
+++ b/src/Loggers/Formatters/QueryFormatter.php
@@ -2,13 +2,17 @@
 
 namespace LaravelDoctrine\ORM\Loggers\Formatters;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
 interface QueryFormatter
 {
     /**
+     * @param AbstractPlatform $platform
      * @param string     $sql
      * @param array|null $params
+     * @param array|null $types
      *
      * @return string
      */
-    public function format($sql, array $params = null);
+    public function format($platform, $sql, array $params = null, array $types = null);
 }

--- a/src/Loggers/Formatters/ReplaceQueryParams.php
+++ b/src/Loggers/Formatters/ReplaceQueryParams.php
@@ -12,10 +12,10 @@ class ReplaceQueryParams implements QueryFormatter
 {
     /**
      * @param AbstractPlatform $platform
-     * @param string     $sql
-     * @param array|null $params
-     * @param array|null $types
-     * 
+     * @param string           $sql
+     * @param array|null       $params
+     * @param array|null       $types
+     *
      *
      * @return string
      */
@@ -23,7 +23,7 @@ class ReplaceQueryParams implements QueryFormatter
     {
         if (is_array($params)) {
             foreach ($params as $key => $param) {
-                $type = $types[$key] ?? null;
+                $type  = $types[$key] ?? null;
                 $param = $this->convertParam($platform, $param, $type);
                 $sql   = preg_replace('/\?/', "$param", $sql, 1);
             }
@@ -44,8 +44,8 @@ class ReplaceQueryParams implements QueryFormatter
             if (!method_exists($param, '__toString')) {
                 if ($param instanceof DateTimeInterface) {
                     $param = $param->format('Y-m-d H:i:s');
-                } elseif(Type::hasType($type)){
-                    $type = Type::getType($type);
+                } elseif (Type::hasType($type)) {
+                    $type  = Type::getType($type);
                     $param = $type->convertToDatabaseValue($param, $platform);
                 } else {
                     throw new Exception('Given query param is an instance of ' . get_class($param) . ' and could not be converted to a string');

--- a/src/Loggers/Formatters/ReplaceQueryParams.php
+++ b/src/Loggers/Formatters/ReplaceQueryParams.php
@@ -3,22 +3,28 @@
 namespace LaravelDoctrine\ORM\Loggers\Formatters;
 
 use DateTimeInterface;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
 use Exception;
 use function is_array;
 
 class ReplaceQueryParams implements QueryFormatter
 {
     /**
+     * @param AbstractPlatform $platform
      * @param string     $sql
      * @param array|null $params
+     * @param array|null $types
+     * 
      *
      * @return string
      */
-    public function format($sql, array $params = null)
+    public function format($platform, $sql, array $params = null, array $types = null)
     {
         if (is_array($params)) {
-            foreach ($params as $param) {
-                $param = $this->convertParam($param);
+            foreach ($params as $key => $param) {
+                $type = $types[$key] ?? null;
+                $param = $this->convertParam($platform, $param, $type);
                 $sql   = preg_replace('/\?/', "$param", $sql, 1);
             }
         }
@@ -32,12 +38,15 @@ class ReplaceQueryParams implements QueryFormatter
      * @throws Exception
      * @return string
      */
-    protected function convertParam($param)
+    protected function convertParam($platform, $param, $type = null)
     {
         if (is_object($param)) {
             if (!method_exists($param, '__toString')) {
                 if ($param instanceof DateTimeInterface) {
                     $param = $param->format('Y-m-d H:i:s');
+                } elseif(Type::hasType($type)){
+                    $type = Type::getType($type);
+                    $param = $type->convertToDatabaseValue($param, $platform);
                 } else {
                     throw new Exception('Given query param is an instance of ' . get_class($param) . ' and could not be converted to a string');
                 }

--- a/tests/Loggers/Clockwork/DoctrineDataSourceTest.php
+++ b/tests/Loggers/Clockwork/DoctrineDataSourceTest.php
@@ -3,6 +3,8 @@
 use Clockwork\Request\Request;
 use Doctrine\DBAL\Logging\DebugStack;
 use LaravelDoctrine\ORM\Loggers\Clockwork\DoctrineDataSource;
+use Mockery as m;
+use Mockery\Mock;
 
 class DoctrineDataSourceTest extends PHPUnit_Framework_TestCase
 {
@@ -16,6 +18,16 @@ class DoctrineDataSourceTest extends PHPUnit_Framework_TestCase
      */
     protected $source;
 
+    /**
+     * @var Doctrine\DBAL\Connection
+     */
+    protected $connection;
+
+    /**
+     * @var Mock
+     */
+    protected $driver;
+
     protected function setUp()
     {
         $this->logger          = new DebugStack;
@@ -27,7 +39,15 @@ class DoctrineDataSourceTest extends PHPUnit_Framework_TestCase
             ]
         ];
 
-        $this->source = new DoctrineDataSource($this->logger, 'mysql');
+        $this->connection = m::mock(\Doctrine\DBAL\Connection::class);
+        $this->driver = m::mock(\Doctrine\DBAL\Driver::class);
+
+        $this->driver->shouldReceive('getName')->once()->andReturn('mysql');
+
+        $this->connection->shouldReceive('getDriver')->once()->andReturn($this->driver);
+        $this->connection->shouldReceive('getDatabasePlatform')->once()->andReturn('mysql');
+
+        $this->source = new DoctrineDataSource($this->logger, $this->connection);
     }
 
     public function test_transforms_debugstack_query_log_to_clockwork_compatible_array()

--- a/tests/Loggers/Clockwork/DoctrineDataSourceTest.php
+++ b/tests/Loggers/Clockwork/DoctrineDataSourceTest.php
@@ -40,7 +40,7 @@ class DoctrineDataSourceTest extends PHPUnit_Framework_TestCase
         ];
 
         $this->connection = m::mock(\Doctrine\DBAL\Connection::class);
-        $this->driver = m::mock(\Doctrine\DBAL\Driver::class);
+        $this->driver     = m::mock(\Doctrine\DBAL\Driver::class);
 
         $this->driver->shouldReceive('getName')->once()->andReturn('mysql');
 

--- a/tests/Loggers/ClockworkLoggerTest.php
+++ b/tests/Loggers/ClockworkLoggerTest.php
@@ -31,4 +31,9 @@ class ClockworkLoggerTest extends PHPUnit_Framework_TestCase
 
         $logger->register($em, $configuration);
     }
+
+    protected function tearDown()
+    {
+        m::close();
+    }
 }

--- a/tests/Loggers/EchoLoggerTest.php
+++ b/tests/Loggers/EchoLoggerTest.php
@@ -19,4 +19,9 @@ class EchoLoggerTest extends PHPUnit_Framework_TestCase
 
         $logger->register($em, $configuration);
     }
+
+    protected function tearDown()
+    {
+        m::close();
+    }
 }

--- a/tests/Loggers/File/DoctrineFileLoggerTest.php
+++ b/tests/Loggers/File/DoctrineFileLoggerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Doctrine\DBAL\Connection;
 use LaravelDoctrine\ORM\Loggers\File\DoctrineFileLogger;
 use Mockery as m;
 use Mockery\Mock;
@@ -17,17 +18,25 @@ class DoctrineFileLoggerTest extends PHPUnit_Framework_TestCase
      */
     protected $writer;
 
+    /**
+     * @var Mock
+     */
+    protected $connection;
+
     protected function setUp()
     {
         $this->writer = m::mock(Log::class);
+        $this->connection = m::mock(Connection::class);
         $this->logger = new DoctrineFileLogger(
-            $this->writer
+            $this->writer,
+            $this->connection
         );
     }
 
     public function test_transforms_debugstack_query_log_to_clockwork_compatible_array()
     {
         $this->writer->shouldReceive('debug')->once();
+        $this->connection->shouldReceive('getDatabasePlatform')->once();
 
         $this->logger->startQuery('SELECT * FROM table WHERE condition = ?', ['value']);
         $this->logger->stopQuery();

--- a/tests/Loggers/File/DoctrineFileLoggerTest.php
+++ b/tests/Loggers/File/DoctrineFileLoggerTest.php
@@ -25,9 +25,9 @@ class DoctrineFileLoggerTest extends PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->writer = m::mock(Log::class);
+        $this->writer     = m::mock(Log::class);
         $this->connection = m::mock(Connection::class);
-        $this->logger = new DoctrineFileLogger(
+        $this->logger     = new DoctrineFileLogger(
             $this->writer,
             $this->connection
         );

--- a/tests/Loggers/FileLoggerTest.php
+++ b/tests/Loggers/FileLoggerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use LaravelDoctrine\ORM\Loggers\FileLogger;
@@ -17,8 +18,16 @@ class FileLoggerTest extends PHPUnit_Framework_TestCase
         $configuration->shouldReceive('setSQLLogger')
                       ->once();
 
+        $em->shouldReceive('getConnection')
+            ->once()->andReturn(m::mock(Connection::class));
+
         $logger = new FileLogger($writer);
 
         $logger->register($em, $configuration);
+    }
+
+    protected function tearDown()
+    {
+        m::close();
     }
 }

--- a/tests/Loggers/Formatters/FormatQueryKeywordsTest.php
+++ b/tests/Loggers/Formatters/FormatQueryKeywordsTest.php
@@ -33,7 +33,7 @@ class FormatQueryKeywordsTest extends PHPUnit_Framework_TestCase
     {
         $sql    = "select * from table where condition is not null having count(id) > 10 limit 10 offset 10 group by parent order by position desc";
         $params = [];
-        $types = [];
+        $types  = [];
 
         $this->decorate($this->platform, $sql, $params, $types);
 
@@ -44,7 +44,7 @@ class FormatQueryKeywordsTest extends PHPUnit_Framework_TestCase
     {
         $sql    = "insert into table (column1, column2, column3) values (value1, value2, value3)";
         $params = [];
-        $types = [];
+        $types  = [];
 
         $this->decorate($this->platform, $sql, $params, $types);
 
@@ -55,7 +55,7 @@ class FormatQueryKeywordsTest extends PHPUnit_Framework_TestCase
     {
         $sql    = "update table set column1=value, column2=value2 where some_column=some_value";
         $params = [];
-        $types = [];
+        $types  = [];
 
         $this->decorate($this->platform, $sql, $params, $types);
 
@@ -66,7 +66,7 @@ class FormatQueryKeywordsTest extends PHPUnit_Framework_TestCase
     {
         $sql    = "update table set column1=value, column2=value2 where some_column=some_value";
         $params = [];
-        $types = [];
+        $types  = [];
 
         $this->decorate($this->platform, $sql, $params, $types);
 

--- a/tests/Loggers/Formatters/FormatQueryKeywordsTest.php
+++ b/tests/Loggers/Formatters/FormatQueryKeywordsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use LaravelDoctrine\ORM\Loggers\Formatters\FormatQueryKeywords;
 use LaravelDoctrine\ORM\Loggers\Formatters\QueryFormatter;
 use Mockery as m;
@@ -17,9 +18,13 @@ class FormatQueryKeywordsTest extends PHPUnit_Framework_TestCase
      */
     protected $formatter;
 
+    protected $platform;
+
     protected function setUp()
     {
         $this->mock = m::mock(QueryFormatter::class);
+
+        $this->platform = m::mock(AbstractPlatform::class);
 
         $this->formatter = new FormatQueryKeywords($this->mock);
     }
@@ -28,40 +33,44 @@ class FormatQueryKeywordsTest extends PHPUnit_Framework_TestCase
     {
         $sql    = "select * from table where condition is not null having count(id) > 10 limit 10 offset 10 group by parent order by position desc";
         $params = [];
+        $types = [];
 
-        $this->decorate($sql, $params);
+        $this->decorate($this->platform, $sql, $params, $types);
 
-        $this->assertEquals('SELECT * FROM table WHERE condition IS NOT NULL HAVING COUNT(id) > 10 LIMIT 10 OFFSET 10 GROUP BY parent ORDER BY position DESC', $this->formatter->format($sql, $params));
+        $this->assertEquals('SELECT * FROM table WHERE condition IS NOT NULL HAVING COUNT(id) > 10 LIMIT 10 OFFSET 10 GROUP BY parent ORDER BY position DESC', $this->formatter->format($this->platform, $sql, $params, $types));
     }
 
     public function test_formats_insert_queries()
     {
         $sql    = "insert into table (column1, column2, column3) values (value1, value2, value3)";
         $params = [];
+        $types = [];
 
-        $this->decorate($sql, $params);
+        $this->decorate($this->platform, $sql, $params, $types);
 
-        $this->assertEquals('INSERT INTO table (column1, column2, column3) VALUES (value1, value2, value3)', $this->formatter->format($sql, $params));
+        $this->assertEquals('INSERT INTO table (column1, column2, column3) VALUES (value1, value2, value3)', $this->formatter->format($this->platform, $sql, $params, $types));
     }
 
     public function test_formats_update_queries()
     {
         $sql    = "update table set column1=value, column2=value2 where some_column=some_value";
         $params = [];
+        $types = [];
 
-        $this->decorate($sql, $params);
+        $this->decorate($this->platform, $sql, $params, $types);
 
-        $this->assertEquals('UPDATE table SET column1=value, column2=value2 WHERE some_column=some_value', $this->formatter->format($sql, $params));
+        $this->assertEquals('UPDATE table SET column1=value, column2=value2 WHERE some_column=some_value', $this->formatter->format($this->platform, $sql, $params, $types));
     }
 
     public function test_formats_delete_queries()
     {
         $sql    = "update table set column1=value, column2=value2 where some_column=some_value";
         $params = [];
+        $types = [];
 
-        $this->decorate($sql, $params);
+        $this->decorate($this->platform, $sql, $params, $types);
 
-        $this->assertEquals('UPDATE table SET column1=value, column2=value2 WHERE some_column=some_value', $this->formatter->format($sql, $params));
+        $this->assertEquals('UPDATE table SET column1=value, column2=value2 WHERE some_column=some_value', $this->formatter->format($this->platform, $sql, $params, $types));
     }
 
     protected function tearDown()
@@ -69,8 +78,8 @@ class FormatQueryKeywordsTest extends PHPUnit_Framework_TestCase
         m::close();
     }
 
-    protected function decorate($sql, $params)
+    protected function decorate($platform, $sql, $params, $types)
     {
-        $this->mock->shouldReceive('format')->once()->with($sql, $params)->andReturn($sql);
+        $this->mock->shouldReceive('format')->once()->with($platform, $sql, $params, $types)->andReturn($sql);
     }
 }

--- a/tests/Loggers/Formatters/ReplaceQueryParamsTest.php
+++ b/tests/Loggers/Formatters/ReplaceQueryParamsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\JsonArrayType;
 use Doctrine\DBAL\Types\Type;
 use LaravelDoctrine\ORM\Loggers\Formatters\ReplaceQueryParams;
 use Mockery as m;
@@ -20,7 +21,7 @@ class ReplaceQueryParamsTest extends PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->platform = m::mock(AbstractPlatform::class);
+        $this->platform  = m::mock(AbstractPlatform::class);
         $this->formatter = new ReplaceQueryParams;
     }
 
@@ -137,9 +138,9 @@ class ReplaceQueryParamsTest extends PHPUnit_Framework_TestCase
     {
         $sql    = 'UPDATE table foo SET column = ?';
         $params = [new ObjectClass()];
-        $types = ['object_type'];
+        $types  = ['object_type'];
 
-        if(!Type::hasType('object_type')){
+        if (!Type::hasType('object_type')) {
             Type::addType('object_type', ObjectType::class);
         }
 
@@ -168,9 +169,8 @@ class StringClass
     }
 }
 
-class ObjectType extends Doctrine\DBAL\Types\JsonType
+class ObjectType extends JsonArrayType
 {
-
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
         return json_encode(get_object_vars($value));


### PR DESCRIPTION
If using custom type(i using type https://github.com/Hunternnm/laravel-doctrine-odm/blob/master/src/JsonDocumentType.php from my mini-ODM) formatter crash if not exists `__toString` method, ignoring types method `convertToDatabaseValue`