### PR TITLE
[Feature] Allow paths to be loaded into entity factory

### DIFF
--- a/src/Testing/Factory.php
+++ b/src/Testing/Factory.php
@@ -60,15 +60,7 @@ class Factory implements ArrayAccess
     {
         $pathToFactories = $pathToFactories ?: database_path('factories');
 
-        $factory = new static($faker, $registry);
-
-        if (is_dir($pathToFactories)) {
-            foreach (Finder::create()->files()->in($pathToFactories) as $file) {
-                require $file->getRealPath();
-            }
-        }
-
-        return $factory;
+        return (new static($faker, $registry))->load($pathToFactories);
     }
 
     /**
@@ -201,6 +193,26 @@ class Factory implements ArrayAccess
             $this->faker,
             $this->getStateFor($class)
         );
+    }
+
+    /**
+     * Load factories from path.
+     *
+     * @param string $path
+     *
+     * @return $this
+     */
+    public function load($path)
+    {
+        $factory = $this;
+
+        if (is_dir($path)) {
+            foreach (Finder::create()->files()->in($path) as $file) {
+                require $file->getRealPath();
+            }
+        }
+
+        return $factory;
     }
 
     /**


### PR DESCRIPTION
Adds a load method to the entity factory so that factories can be loaded from additional paths. This is particularly useful if using entity factories exist in a package rather than a Laravel app.

Additionally this pattern matches the behaviour of the Eloquent factory, which allows additional paths to be loaded via a load method.