### PR TITLE
[Fix] SubstituteBindings to use findOneBy()

### DIFF
--- a/src/Middleware/SubstituteBindings.php
+++ b/src/Middleware/SubstituteBindings.php
@@ -71,7 +71,7 @@ class SubstituteBindings
                 if ($parameter->getClass()->implementsInterface(UrlRoutable::class)) {
                     $name = call_user_func([$class, 'getRouteKeyName']);
 
-                    $entity = $repository->findBy([
+                    $entity = $repository->findOneBy([
                         $name => $id
                     ]);
                 } else {

--- a/tests/Middleware/SubstituteBindingsTest.php
+++ b/tests/Middleware/SubstituteBindingsTest.php
@@ -161,7 +161,7 @@ class SubstituteBindingsTest extends PHPUnit_Framework_TestCase
         $entity       = new BindableEntityWithInterface();
         $entity->id   = 1;
         $entity->name = 'NAMEVALUE';
-        $this->repository->shouldReceive('findBy')->once()->with(['name' => 'NAMEVALUE'])->andReturn($entity);
+        $this->repository->shouldReceive('findOneBy')->with(['name' => 'NAMEVALUE'])->andReturn($entity);
 
         $this->assertEquals(1, $router->dispatch(Request::create('foo/NAMEVALUE', 'GET'))->getContent());
     }


### PR DESCRIPTION
The function findBy() will bring back an array of results, when, for the implicit bind to work, only one entity is expected.

### Changes proposed in this pull request:
- Replace the function findBy() for the function findOneBy()