### PR TITLE
deprecate console commands that will be removed in Doctrine ORM 3

### DIFF
--- a/src/Console/ConvertMappingCommand.php
+++ b/src/Console/ConvertMappingCommand.php
@@ -41,6 +41,9 @@ class ConvertMappingCommand extends Command
      */
     public function handle(ManagerRegistry $registry)
     {
+        $this->error('The doctrine:convert:mapping command has been deprecated and will be removed in Doctrine ORM 3');
+
+
         $names = $this->option('em') ? [$this->option('em')] : $registry->getManagerNames();
 
         foreach ($names as $name) {

--- a/src/Console/GenerateEntitiesCommand.php
+++ b/src/Console/GenerateEntitiesCommand.php
@@ -39,6 +39,9 @@ class GenerateEntitiesCommand extends Command
      */
     public function handle(ManagerRegistry $registry)
     {
+        $this->error('The doctrine:generate:entities command has been deprecated and will be removed in Doctrine ORM 3');
+
+
         $names = $this->option('em') ? [$this->option('em')] : $registry->getManagerNames();
 
         foreach ($names as $name) {

--- a/src/Console/GenerateRepositoriesCommand.php
+++ b/src/Console/GenerateRepositoriesCommand.php
@@ -32,6 +32,9 @@ class GenerateRepositoriesCommand extends Command
      */
     public function handle(ManagerRegistry $registry)
     {
+        $this->error('The doctrine:generate:repositories command has been deprecated and will be removed in Doctrine ORM 3');
+
+
         $names = $this->option('em') ? [$this->option('em')] : $registry->getManagerNames();
 
         foreach ($names as $name) {

--- a/src/Console/MappingImportCommand.php
+++ b/src/Console/MappingImportCommand.php
@@ -54,6 +54,9 @@ class MappingImportCommand extends Command
                 $type       = 'yaml';
             }
         }
+        if ($type === 'yaml') {
+            $this->error('The yaml mapping type in doctrine:mapping:import command has been deprecated and will be removed in Doctrine ORM 3');
+        }
 
         $cme      = new ClassMetadataExporter();
         $exporter = $cme->getExporter($type);


### PR DESCRIPTION
Please prefix your pull request with one of the following: [FIX].

### Changes proposed in this pull request:
- deprecate `doctrine:convert:mapping`
- deprecate `doctrine:generate:entities`
- deprecate `doctrine:generate:repositories`

why
since [upgrade guide notices this](https://github.com/doctrine/doctrine2/blob/master/UPGRADE.md#bc-break-removed-code-generators-and-related-console-commands) and also [doctrine/DoctrineBundle](https://github.com/doctrine/DoctrineBundle/blob/master/Command/GenerateEntitiesDoctrineCommand.php#L79) does this
