### PR TITLE
[FEATURE] update dependencies and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 
 php:
-  - 7.0
-  - 7.1
+  - 7.2
 
 before_script:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
-        "doctrine/orm": "2.5.*|2.6.*",
+        "php": "^7.2",
+        "doctrine/orm": "2.6.*",
         "illuminate/auth": "5.5.*|5.6.*|5.7.*",
         "illuminate/console": "5.5.*|5.6.*|5.7.*",
         "illuminate/container": "5.5.*|5.6.*|5.7.*",
@@ -27,16 +27,20 @@
         "illuminate/support": "5.5.*|5.6.*|5.7.*",
         "illuminate/validation": "5.5.*|5.6.*|5.7.*",
         "illuminate/view": "5.5.*|5.6.*|5.7.*",
-        "symfony/serializer": "^2.7|~3.0|~4.0"
+        "symfony/serializer": "^3.4|~4.0",
+        "itsgoingd/clockwork": "^3.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0",
+        "ext-json": "*",
         "mockery/mockery": "^1.0",
-        "barryvdh/laravel-debugbar": "~2.0",
-        "itsgoingd/clockwork": "~1.9",
         "illuminate/log": "5.5.*|5.6.*|5.7.*",
         "illuminate/notifications": "5.5.*|5.6.*|5.7.*",
-        "illuminate/queue": "5.5.*|5.6.*|5.7.*"
+        "illuminate/queue": "5.5.*|5.6.*|5.7.*",
+        "barryvdh/laravel-debugbar": "^3.2",
+        "phpunit/phpunit": "~7.0"
+    },
+    "config": {
+        "sort-packages": true
     },
     "autoload": {
         "psr-4": {
@@ -47,8 +51,11 @@
         ]
     },
     "autoload-dev": {
-        "classmap": [
-            "tests"
+        "psr-4": {
+            "LaravelDoctrine\\Tests\\": "tests/"
+        },
+        "files": [
+            "tests/functions.php"
         ]
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,7 @@
     "require": {
         "php": "^7.2",
         "doctrine/orm": "2.6.*",
-        "illuminate/auth": "5.5.*|5.6.*|5.7.*",
-        "illuminate/console": "5.5.*|5.6.*|5.7.*",
-        "illuminate/container": "5.5.*|5.6.*|5.7.*",
-        "illuminate/contracts": "5.5.*|5.6.*|5.7.*",
-        "illuminate/pagination": "5.5.*|5.6.*|5.7.*",
-        "illuminate/routing": "5.5.*|5.6.*|5.7.*",
-        "illuminate/support": "5.5.*|5.6.*|5.7.*",
-        "illuminate/validation": "5.5.*|5.6.*|5.7.*",
-        "illuminate/view": "5.5.*|5.6.*|5.7.*",
+        "laravel/framework": "5.5.*|5.6.*|5.7.*",
         "symfony/serializer": "^3.4|~4.0",
         "itsgoingd/clockwork": "^3.1"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,7 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
+         beStrictAboutTestsThatDoNotTestAnything="false"
         >
     <testsuites>
         <testsuite name="Package Test Suite">

--- a/src/Testing/Factory.php
+++ b/src/Testing/Factory.php
@@ -4,7 +4,7 @@ namespace LaravelDoctrine\ORM\Testing;
 
 use ArrayAccess;
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Faker\Generator as Faker;
+use LaravelDoctrine\Tests\Stubs\Faker\Generator;
 use Symfony\Component\Finder\Finder;
 
 class Factory implements ArrayAccess
@@ -12,7 +12,7 @@ class Factory implements ArrayAccess
     /**
      * The Faker instance for the builder.
      *
-     * @var \Faker\Generator
+     * @var Generator
      */
     protected $faker;
 
@@ -38,10 +38,10 @@ class Factory implements ArrayAccess
     /**
      * Create a new factory instance.
      *
-     * @param \Faker\Generator $faker
+     * @param Generator $faker
      * @param ManagerRegistry  $registry
      */
-    public function __construct(Faker $faker, ManagerRegistry $registry)
+    public function __construct(Generator $faker, ManagerRegistry $registry)
     {
         $this->faker    = $faker;
         $this->registry = $registry;
@@ -50,13 +50,13 @@ class Factory implements ArrayAccess
     /**
      * Create a new factory container.
      *
-     * @param \Faker\Generator $faker
+     * @param Generator $faker
      * @param ManagerRegistry  $registry
      * @param string|null      $pathToFactories
      *
      * @return static
      */
-    public static function construct(Faker $faker, ManagerRegistry $registry, $pathToFactories = null)
+    public static function construct(Generator $faker, ManagerRegistry $registry, $pathToFactories = null)
     {
         $pathToFactories = $pathToFactories ?: database_path('factories');
 

--- a/src/Testing/FactoryBuilder.php
+++ b/src/Testing/FactoryBuilder.php
@@ -5,9 +5,9 @@ namespace LaravelDoctrine\ORM\Testing;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Faker\Generator as Faker;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
+use LaravelDoctrine\Tests\Stubs\Faker\Generator;
 
 class FactoryBuilder
 {
@@ -72,9 +72,9 @@ class FactoryBuilder
      * @param string           $class
      * @param string           $name
      * @param array            $definitions
-     * @param \Faker\Generator $faker
+     * @param Generator $faker
      */
-    public function __construct(ManagerRegistry $registry, $class, $name, array $definitions, Faker $faker)
+    public function __construct(ManagerRegistry $registry, $class, $name, array $definitions, Generator $faker)
     {
         $this->name        = $name;
         $this->class       = $class;
@@ -88,12 +88,12 @@ class FactoryBuilder
      * @param string          $class
      * @param string          $name
      * @param array           $definitions
-     * @param Faker           $faker
+     * @param Generator       $faker
      * @param array           $states
      *
      * @return FactoryBuilder
      */
-    public static function construct(ManagerRegistry $registry, $class, $name, array $definitions, Faker $faker, array $states)
+    public static function construct(ManagerRegistry $registry, $class, $name, array $definitions, Generator $faker, array $states)
     {
         $instance         = new static($registry, $class, $name, $definitions, $faker);
         $instance->states = $states;

--- a/tests/Auth/DoctrineUserProviderTest.php
+++ b/tests/Auth/DoctrineUserProviderTest.php
@@ -1,15 +1,17 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Auth;
+
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
-use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Hashing\Hasher;
-use LaravelDoctrine\ORM\Auth\Authenticatable;
 use LaravelDoctrine\ORM\Auth\DoctrineUserProvider;
+use LaravelDoctrine\Tests\Mocks\AuthenticatableMock;
+use LaravelDoctrine\Tests\Mocks\AuthenticatableWithNonEmptyConstructorMock;
 use Mockery as m;
 use Mockery\Mock;
 
-class DoctrineUserProviderTest extends PHPUnit_Framework_TestCase
+class DoctrineUserProviderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Mock
@@ -45,12 +47,12 @@ class DoctrineUserProviderTest extends PHPUnit_Framework_TestCase
         $this->provider = new DoctrineUserProvider(
             $this->hasher,
             $this->em,
-            AuthenticableMock::class
+            AuthenticatableMock::class
         );
         $this->providerNonEmpty = new DoctrineUserProvider(
             $this->hasher,
             $this->em,
-            AuthenticableWithNonEmptyConstructorMock::class
+            AuthenticatableWithNonEmptyConstructorMock::class
         );
     }
 
@@ -58,7 +60,7 @@ class DoctrineUserProviderTest extends PHPUnit_Framework_TestCase
     {
         $this->mockGetRepository();
 
-        $user = new AuthenticableMock;
+        $user = new AuthenticatableMock;
         $this->repo->shouldReceive('find')
                    ->once()->with(1)
                    ->andReturn($user);
@@ -70,7 +72,7 @@ class DoctrineUserProviderTest extends PHPUnit_Framework_TestCase
     {
         $this->mockGetRepository();
 
-        $user = new AuthenticableMock;
+        $user = new AuthenticatableMock;
         $this->repo->shouldReceive('findOneBy')
                    ->with([
                        'id'            => 1,
@@ -83,9 +85,9 @@ class DoctrineUserProviderTest extends PHPUnit_Framework_TestCase
 
     public function test_can_retrieve_by_token_with_non_empty_constructor()
     {
-        $this->mockGetRepository(AuthenticableWithNonEmptyConstructorMock::class);
+        $this->mockGetRepository(AuthenticatableWithNonEmptyConstructorMock::class);
 
-        $user = new AuthenticableWithNonEmptyConstructorMock(['myPassword']);
+        $user = new AuthenticatableWithNonEmptyConstructorMock(['myPassword']);
         $this->repo->shouldReceive('findOneBy')
                    ->with([
                        'id'            => 1,
@@ -98,7 +100,7 @@ class DoctrineUserProviderTest extends PHPUnit_Framework_TestCase
 
     public function test_can_update_remember_token()
     {
-        $user = new AuthenticableMock;
+        $user = new AuthenticatableMock;
 
         $this->em->shouldReceive('persist')->once()->with($user);
         $this->em->shouldReceive('flush')->once()->with($user);
@@ -112,7 +114,7 @@ class DoctrineUserProviderTest extends PHPUnit_Framework_TestCase
     {
         $this->mockGetRepository();
 
-        $user = new AuthenticableMock;
+        $user = new AuthenticatableMock;
         $this->repo->shouldReceive('findOneBy')
                    ->with([
                        'email' => 'email',
@@ -127,7 +129,7 @@ class DoctrineUserProviderTest extends PHPUnit_Framework_TestCase
 
     public function test_can_validate_credentials()
     {
-        $user = new AuthenticableMock;
+        $user = new AuthenticatableMock;
 
         $this->hasher->shouldReceive('check')->once()
                      ->with('myPassword', 'myPassword')
@@ -139,7 +141,7 @@ class DoctrineUserProviderTest extends PHPUnit_Framework_TestCase
         ));
     }
 
-    protected function mockGetRepository($class = AuthenticableMock::class)
+    protected function mockGetRepository($class = AuthenticatableMock::class)
     {
         $this->em->shouldReceive('getRepository')
                  ->with($class)
@@ -149,25 +151,5 @@ class DoctrineUserProviderTest extends PHPUnit_Framework_TestCase
     protected function tearDown()
     {
         m::close();
-    }
-}
-
-class AuthenticableMock implements AuthenticatableContract
-{
-    use Authenticatable;
-
-    public function __construct()
-    {
-        $this->password = 'myPassword';
-    }
-}
-
-class AuthenticableWithNonEmptyConstructorMock implements AuthenticatableContract
-{
-    use Authenticatable;
-
-    public function __construct(array $passwords)
-    {
-        $this->password = $passwords[0];
     }
 }

--- a/tests/Auth/Passwords/DoctrineTokenRepositoryTest.php
+++ b/tests/Auth/Passwords/DoctrineTokenRepositoryTest.php
@@ -1,15 +1,17 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Auth\Passwords;
+
 use Carbon\Carbon;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
-use Illuminate\Contracts\Auth\CanResetPassword;
 use LaravelDoctrine\ORM\Auth\Passwords\DoctrineTokenRepository;
+use LaravelDoctrine\Tests\Mocks\UserMock;
 use Mockery as m;
 use Mockery\Mock;
 
-class DoctrineTokenRepositoryTest extends PHPUnit_Framework_TestCase
+class DoctrineTokenRepositoryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Mock
@@ -209,28 +211,5 @@ class DoctrineTokenRepositoryTest extends PHPUnit_Framework_TestCase
     protected function tearDown()
     {
         m::close();
-    }
-}
-
-class UserMock implements CanResetPassword
-{
-    /**
-     * Get the e-mail address where password reset links are sent.
-     * @return string
-     */
-    public function getEmailForPasswordReset()
-    {
-        return 'user@mockery.mock';
-    }
-
-    /**
-     * Send the password reset notification.
-     *
-     * @param  string $token
-     * @return void
-     */
-    public function sendPasswordResetNotification($token)
-    {
-        // TODO: Implement sendPasswordResetNotification() method.
     }
 }

--- a/tests/Configuration/Cache/AbstractCacheProviderTest.php
+++ b/tests/Configuration/Cache/AbstractCacheProviderTest.php
@@ -1,8 +1,12 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\Cache;
 
-abstract class AbstractCacheProviderTest extends PHPUnit_Framework_TestCase
+abstract class AbstractCacheProviderTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @return \LaravelDoctrine\ORM\Configuration\Driver
+     */
     abstract public function getProvider();
 
     abstract public function getExpectedInstance();
@@ -14,6 +18,6 @@ abstract class AbstractCacheProviderTest extends PHPUnit_Framework_TestCase
 
     public function tearDown()
     {
-        Mockery::close();
+        \Mockery::close();
     }
 }

--- a/tests/Configuration/Cache/AbstractCacheTest.php
+++ b/tests/Configuration/Cache/AbstractCacheTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\Cache;
+
 use Mockery as m;
 
 abstract class AbstractCacheTest
@@ -86,7 +88,7 @@ abstract class AbstractCacheTest
                     ->once()->andReturn('cacheKey');
 
         $this->getStore()->shouldReceive('put')
-                    ->with("DoctrineNamespaceCacheKey[]", 1, false)
+                    ->with('DoctrineNamespaceCacheKey[]', 1, false)
                     ->once()->andReturn(true);
 
         $this->assertTrue($this->getCache()->deleteAll());

--- a/tests/Configuration/Cache/ApcCacheProviderTest.php
+++ b/tests/Configuration/Cache/ApcCacheProviderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\Cache;
+
 use Illuminate\Contracts\Cache\Factory;
 use Illuminate\Contracts\Cache\Repository;
 use LaravelDoctrine\ORM\Configuration\Cache\ApcCacheProvider;

--- a/tests/Configuration/Cache/ArrayCacheProviderTest.php
+++ b/tests/Configuration/Cache/ArrayCacheProviderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\Cache;
+
 use Doctrine\Common\Cache\ArrayCache;
 use LaravelDoctrine\ORM\Configuration\Cache\ArrayCacheProvider;
 

--- a/tests/Configuration/Cache/CacheManagerTest.php
+++ b/tests/Configuration/Cache/CacheManagerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\Cache;
+
 use Doctrine\Common\Cache\ArrayCache;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Container\Container;
@@ -9,7 +11,7 @@ use LaravelDoctrine\ORM\Configuration\Cache\FileCacheProvider;
 use LaravelDoctrine\ORM\Exceptions\DriverNotFound;
 use Mockery as m;
 
-class CacheManagerTest extends PHPUnit_Framework_TestCase
+class CacheManagerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var CacheManager
@@ -58,7 +60,7 @@ class CacheManagerTest extends PHPUnit_Framework_TestCase
 
     public function test_cant_resolve_unsupported_drivers()
     {
-        $this->setExpectedException(DriverNotFound::class);
+        $this->expectException(DriverNotFound::class);
         $this->manager->driver('non-existing');
     }
 

--- a/tests/Configuration/Cache/FileCacheProviderTest.php
+++ b/tests/Configuration/Cache/FileCacheProviderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\Cache;
+
 use Doctrine\Common\Cache\FilesystemCache;
 use Illuminate\Contracts\Config\Repository;
 use LaravelDoctrine\ORM\Configuration\Cache\FileCacheProvider;
@@ -26,9 +28,3 @@ class FileCacheProviderTest extends AbstractCacheProviderTest
     }
 }
 
-function storage_path($path = null)
-{
-    $storage = __DIR__ . DIRECTORY_SEPARATOR . '../../Stubs/storage';
-
-    return is_null($path) ? $storage : $storage . DIRECTORY_SEPARATOR . $path;
-}

--- a/tests/Configuration/Cache/IlluminateCacheAdapterTest.php
+++ b/tests/Configuration/Cache/IlluminateCacheAdapterTest.php
@@ -1,10 +1,12 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\Cache;
+
 use Illuminate\Contracts\Cache\Repository;
 use LaravelDoctrine\ORM\Configuration\Cache\IlluminateCacheAdapter;
 use Mockery as m;
 
-class IlluminateCacheAdapterTest extends PHPUnit_Framework_TestCase
+class IlluminateCacheAdapterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var IlluminateCacheAdapter

--- a/tests/Configuration/Cache/MemcachedCacheProviderTest.php
+++ b/tests/Configuration/Cache/MemcachedCacheProviderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\Cache;
+
 use Illuminate\Contracts\Cache\Factory;
 use Illuminate\Contracts\Cache\Repository;
 use LaravelDoctrine\ORM\Configuration\Cache\IlluminateCacheAdapter;

--- a/tests/Configuration/Cache/RedisCacheProviderTest.php
+++ b/tests/Configuration/Cache/RedisCacheProviderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\Cache;
+
 use Illuminate\Contracts\Cache\Factory;
 use Illuminate\Contracts\Cache\Repository;
 use LaravelDoctrine\ORM\Configuration\Cache\IlluminateCacheAdapter;

--- a/tests/Configuration/Cache/VoidCacheProviderTest.php
+++ b/tests/Configuration/Cache/VoidCacheProviderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\Cache;
+
 use Doctrine\Common\Cache\VoidCache;
 use LaravelDoctrine\ORM\Configuration\Cache\VoidCacheProvider;
 

--- a/tests/Configuration/Connections/ConnectionManagerTest.php
+++ b/tests/Configuration/Connections/ConnectionManagerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\Connections;
+
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Container\Container;
 use LaravelDoctrine\ORM\Configuration\Connections\ConnectionManager;
@@ -8,7 +10,7 @@ use LaravelDoctrine\ORM\Configuration\Connections\SqliteConnection;
 use LaravelDoctrine\ORM\Exceptions\DriverNotFound;
 use Mockery as m;
 
-class ConnectionManagerTest extends PHPUnit_Framework_TestCase
+class ConnectionManagerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var ConnectionManager
@@ -60,7 +62,7 @@ class ConnectionManagerTest extends PHPUnit_Framework_TestCase
 
     public function test_cant_resolve_unsupported_drivers()
     {
-        $this->setExpectedException(DriverNotFound::class);
+        $this->expectException(DriverNotFound::class);
         $this->manager->driver('non-existing');
     }
 

--- a/tests/Configuration/Connections/MasterSlaveConnectionTest.php
+++ b/tests/Configuration/Connections/MasterSlaveConnectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\Connections;
+
 use Doctrine\DBAL\Connections\MasterSlaveConnection as MasterSlaveDoctrineWrapper;
 use Illuminate\Contracts\Config\Repository;
 use LaravelDoctrine\ORM\Configuration\Connections\MasterSlaveConnection;
@@ -8,7 +10,7 @@ use Mockery as m;
 /**
  * Basic unit tests for master slave connection.
  */
-class MasterSlaveConnectionTest extends PHPUnit_Framework_TestCase
+class MasterSlaveConnectionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Data provider for testMasterSlaveConnection.
@@ -28,8 +30,8 @@ class MasterSlaveConnectionTest extends PHPUnit_Framework_TestCase
         // Case #2. Simple valid configuration with oracle base settings.
         $out[] = [$this->getResolvedOracleConfig(), $this->getInputConfig(), $this->getOracleExpectedConfig()];
 
-        // Case #3. Simple valid configuration with pgqsql base settings.
-        $out[] = [$this->getResolvedPgqsqlConfig(), $this->getInputConfig(), $this->getPgsqlExpectedConfig()];
+        // Case #3. Simple valid configuration with pgsql base settings.
+        $out[] = [$this->getResolvedPgsqlConfig(), $this->getInputConfig(), $this->getPgsqlExpectedConfig()];
 
         // Case #4. Simple valid configuration with sqlite base settings.
         $out[] = [$this->getResolvedSqliteConfig(), $this->getSqliteInputConfig(), $this->getSqliteExpectedConfig()];
@@ -282,9 +284,11 @@ class MasterSlaveConnectionTest extends PHPUnit_Framework_TestCase
     private function getSqliteInputConfig()
     {
         $inputConfigSqlite = $this->getInputConfig();
-        unset($inputConfigSqlite['read'][0]['database']);
-        unset($inputConfigSqlite['read'][1]['database']);
-        unset($inputConfigSqlite['write']['database']);
+        unset(
+            $inputConfigSqlite['read'][0]['database'],
+            $inputConfigSqlite['read'][1]['database'],
+            $inputConfigSqlite['write']['database']
+        );
 
         return $inputConfigSqlite;
     }
@@ -347,7 +351,7 @@ class MasterSlaveConnectionTest extends PHPUnit_Framework_TestCase
      *
      * @return array
      */
-    private function getResolvedPgqsqlConfig()
+    private function getResolvedPgsqlConfig()
     {
         return [
             'driver'      => 'pgsql',

--- a/tests/Configuration/Connections/MysqlConnectionTest.php
+++ b/tests/Configuration/Connections/MysqlConnectionTest.php
@@ -1,11 +1,13 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\Connections;
+
 use Illuminate\Contracts\Config\Repository;
 use LaravelDoctrine\ORM\Configuration\Connections\MysqlConnection;
 use Mockery as m;
 use Mockery\Mock;
 
-class MysqlConnectionTest extends PHPUnit_Framework_TestCase
+class MysqlConnectionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Mock

--- a/tests/Configuration/Connections/OracleConnectionTest.php
+++ b/tests/Configuration/Connections/OracleConnectionTest.php
@@ -1,11 +1,13 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\Connections;
+
 use Illuminate\Contracts\Config\Repository;
 use LaravelDoctrine\ORM\Configuration\Connections\OracleConnection;
 use Mockery as m;
 use Mockery\Mock;
 
-class OracleConnectionTest extends PHPUnit_Framework_TestCase
+class OracleConnectionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Mock

--- a/tests/Configuration/Connections/PgsqlConnectionTest.php
+++ b/tests/Configuration/Connections/PgsqlConnectionTest.php
@@ -1,11 +1,13 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\Connections;
+
 use Illuminate\Contracts\Config\Repository;
 use LaravelDoctrine\ORM\Configuration\Connections\PgsqlConnection;
 use Mockery as m;
 use Mockery\Mock;
 
-class PgsqlConnectionTest extends PHPUnit_Framework_TestCase
+class PgsqlConnectionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Mock

--- a/tests/Configuration/Connections/SqliteConnectionTest.php
+++ b/tests/Configuration/Connections/SqliteConnectionTest.php
@@ -1,11 +1,13 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\Connections;
+
 use Illuminate\Contracts\Config\Repository;
 use LaravelDoctrine\ORM\Configuration\Connections\SqliteConnection;
 use Mockery as m;
 use Mockery\Mock;
 
-class SqliteConnectionTest extends PHPUnit_Framework_TestCase
+class SqliteConnectionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Mock

--- a/tests/Configuration/Connections/SqlsrvConnectionTest.php
+++ b/tests/Configuration/Connections/SqlsrvConnectionTest.php
@@ -1,11 +1,13 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\Connections;
+
 use Illuminate\Contracts\Config\Repository;
 use LaravelDoctrine\ORM\Configuration\Connections\SqlsrvConnection;
 use Mockery as m;
 use Mockery\Mock;
 
-class SqlsrvConnectionTest extends PHPUnit_Framework_TestCase
+class SqlsrvConnectionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Mock

--- a/tests/Configuration/CustomTypeManagerTest.php
+++ b/tests/Configuration/CustomTypeManagerTest.php
@@ -1,9 +1,13 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration;
+
 use Doctrine\DBAL\DBALException;
 use LaravelDoctrine\ORM\Configuration\CustomTypeManager;
+use LaravelDoctrine\Tests\Mocks\TypeMock;
+use LaravelDoctrine\Tests\Mocks\TypeMock2;
 
-class CustomTypeManagerTest extends PHPUnit_Framework_TestCase
+class CustomTypeManagerTest extends \PHPUnit\Framework\TestCase
 {
     public function test_can_add_type()
     {
@@ -40,16 +44,9 @@ class CustomTypeManagerTest extends PHPUnit_Framework_TestCase
 
     public function test_cannot_get_non_existing_type()
     {
-        $this->setExpectedException(DBALException::class);
+        $this->expectException(DBALException::class);
 
         $manager = new CustomTypeManager;
         $manager->getType('non_existing');
     }
-}
-
-class TypeMock
-{
-}
-class TypeMock2
-{
 }

--- a/tests/Configuration/LaravelNamingStrategyTest.php
+++ b/tests/Configuration/LaravelNamingStrategyTest.php
@@ -1,9 +1,11 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration;
+
 use Illuminate\Support\Str;
 use LaravelDoctrine\ORM\Configuration\LaravelNamingStrategy;
 
-class LaravelNamingStrategyTest extends PHPUnit_Framework_TestCase
+class LaravelNamingStrategyTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @type LaravelNamingStrategy

--- a/tests/Configuration/MetaData/AnnotationsTest.php
+++ b/tests/Configuration/MetaData/AnnotationsTest.php
@@ -1,11 +1,13 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\MetaData;
+
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use LaravelDoctrine\ORM\Configuration\MetaData\Annotations;
 use Mockery as m;
 
-class AnnotationsTest extends PHPUnit_Framework_TestCase
+class AnnotationsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Annotations

--- a/tests/Configuration/MetaData/Config/ConfigTest.php
+++ b/tests/Configuration/MetaData/Config/ConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\MetaData\Config;
+
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Illuminate\Contracts\Config\Repository;
 use LaravelDoctrine\ORM\Configuration\MetaData\Annotations;
@@ -7,7 +9,7 @@ use LaravelDoctrine\ORM\Configuration\MetaData\Config;
 use Mockery as m;
 use Mockery\Mock;
 
-class ConfigTest extends PHPUnit_Framework_TestCase
+class ConfigTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Mock

--- a/tests/Configuration/MetaData/ConfigDriverTest.php
+++ b/tests/Configuration/MetaData/ConfigDriverTest.php
@@ -1,8 +1,10 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\MetaData;
+
 use LaravelDoctrine\ORM\Configuration\MetaData\Config\ConfigDriver;
 
-class ConfigDriverTest extends PHPUnit_Framework_TestCase
+class ConfigDriverTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var ConfigDriver

--- a/tests/Configuration/MetaData/MetaDataManagerTest.php
+++ b/tests/Configuration/MetaData/MetaDataManagerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\MetaData;
+
 use Illuminate\Contracts\Container\Container;
 use LaravelDoctrine\ORM\Configuration\MetaData\Annotations;
 use LaravelDoctrine\ORM\Configuration\MetaData\MetaDataManager;
@@ -7,7 +9,7 @@ use LaravelDoctrine\ORM\Configuration\MetaData\Yaml;
 use LaravelDoctrine\ORM\Exceptions\DriverNotFound;
 use Mockery as m;
 
-class MetaDataManagerTest extends PHPUnit_Framework_TestCase
+class MetaDataManagerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var MetaDataManager
@@ -45,7 +47,7 @@ class MetaDataManagerTest extends PHPUnit_Framework_TestCase
 
     public function test_cant_resolve_unsupported_drivers()
     {
-        $this->setExpectedException(DriverNotFound::class);
+        $this->expectException(DriverNotFound::class);
         $this->manager->driver('non-existing');
     }
 

--- a/tests/Configuration/MetaData/PhpTest.php
+++ b/tests/Configuration/MetaData/PhpTest.php
@@ -1,11 +1,13 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\MetaData;
+
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Common\Persistence\Mapping\Driver\PHPDriver;
 use LaravelDoctrine\ORM\Configuration\MetaData\Php;
 use Mockery as m;
 
-class PhpTest extends PHPUnit_Framework_TestCase
+class PhpTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Php

--- a/tests/Configuration/MetaData/SimplifiedXmlTest.php
+++ b/tests/Configuration/MetaData/SimplifiedXmlTest.php
@@ -1,11 +1,13 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\MetaData;
+
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver;
 use LaravelDoctrine\ORM\Configuration\MetaData\SimplifiedXml;
 use Mockery as m;
 
-class SimplifiedXmlTest extends PHPUnit_Framework_TestCase
+class SimplifiedXmlTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var SimplifiedXml

--- a/tests/Configuration/MetaData/SimplifiedYamlTest.php
+++ b/tests/Configuration/MetaData/SimplifiedYamlTest.php
@@ -1,11 +1,13 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\MetaData;
+
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\ORM\Mapping\Driver\SimplifiedYamlDriver;
 use LaravelDoctrine\ORM\Configuration\MetaData\SimplifiedYaml;
 use Mockery as m;
 
-class SimplifiedYamlTest extends PHPUnit_Framework_TestCase
+class SimplifiedYamlTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var SimplifiedYaml

--- a/tests/Configuration/MetaData/StaticPhpTest.php
+++ b/tests/Configuration/MetaData/StaticPhpTest.php
@@ -1,11 +1,13 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\MetaData;
+
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Common\Persistence\Mapping\Driver\StaticPHPDriver;
 use LaravelDoctrine\ORM\Configuration\MetaData\StaticPhp;
 use Mockery as m;
 
-class StaticPhpTest extends PHPUnit_Framework_TestCase
+class StaticPhpTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var StaticPhp

--- a/tests/Configuration/MetaData/XmlTest.php
+++ b/tests/Configuration/MetaData/XmlTest.php
@@ -1,11 +1,13 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\MetaData;
+
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use LaravelDoctrine\ORM\Configuration\MetaData\Xml;
 use Mockery as m;
 
-class XmlTest extends PHPUnit_Framework_TestCase
+class XmlTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Xml

--- a/tests/Configuration/MetaData/YamlTest.php
+++ b/tests/Configuration/MetaData/YamlTest.php
@@ -1,11 +1,13 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Configuration\MetaData;
+
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use LaravelDoctrine\ORM\Configuration\MetaData\Yaml;
 use Mockery as m;
 
-class YamlTest extends PHPUnit_Framework_TestCase
+class YamlTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Yaml

--- a/tests/Console/Exporters/FluentExporterTest.php
+++ b/tests/Console/Exporters/FluentExporterTest.php
@@ -1,8 +1,10 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Console\Exporters;
+
 use LaravelDoctrine\ORM\Console\Exporters\FluentExporter;
 
-class FluentExporterTest extends PHPUnit_Framework_TestCase
+class FluentExporterTest extends \PHPUnit\Framework\TestCase
 {
     public function test_it_exports_a_simple_class_metadata()
     {

--- a/tests/DoctrineManagerTest.php
+++ b/tests/DoctrineManagerTest.php
@@ -1,19 +1,21 @@
 <?php
 
+namespace LaravelDoctrine\Tests;
+
 use Doctrine\Common\EventManager;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use Illuminate\Contracts\Container\Container;
+use InvalidArgumentException;
 use LaravelDoctrine\ORM\BootChain;
-use LaravelDoctrine\ORM\DoctrineExtender;
 use LaravelDoctrine\ORM\DoctrineManager;
 use LaravelDoctrine\ORM\EntityManagerFactory;
 use LaravelDoctrine\ORM\Extensions\MappingDriverChain;
 use Mockery as m;
 
-class DoctrineManagerTest extends PHPUnit_Framework_TestCase
+class DoctrineManagerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Container
@@ -77,12 +79,12 @@ class DoctrineManagerTest extends PHPUnit_Framework_TestCase
 
         $this->container->shouldReceive('make')
                         ->once()
-                        ->with(MyDoctrineExtender::class)
-                        ->andReturn(new MyDoctrineExtender);
+                        ->with(Mocks\MyDoctrineExtender::class)
+                        ->andReturn(new Mocks\MyDoctrineExtender);
 
         $this->mockEmCalls();
 
-        $this->manager->extend('default', MyDoctrineExtender::class);
+        $this->manager->extend('default', Mocks\MyDoctrineExtender::class);
 
         BootChain::boot($this->registry);
     }
@@ -94,7 +96,7 @@ class DoctrineManagerTest extends PHPUnit_Framework_TestCase
                        ->with('default')
                        ->andReturn($this->em);
 
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $this->manager->extend('default', 'no_class');
 
@@ -110,12 +112,12 @@ class DoctrineManagerTest extends PHPUnit_Framework_TestCase
 
         $this->container->shouldReceive('make')
                         ->once()
-                        ->with(InvalidDoctrineExtender::class)
-                        ->andReturn(new InvalidDoctrineExtender);
+                        ->with(Mocks\InvalidDoctrineExtender::class)
+                        ->andReturn(new Mocks\InvalidDoctrineExtender);
 
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
-        $this->manager->extend('default', InvalidDoctrineExtender::class);
+        $this->manager->extend('default', Mocks\InvalidDoctrineExtender::class);
 
         BootChain::boot($this->registry);
     }
@@ -221,21 +223,4 @@ class DoctrineManagerTest extends PHPUnit_Framework_TestCase
         $this->em->shouldReceive('getEventManager')
                  ->once()->andReturn(m::mock(EventManager::class));
     }
-}
-
-class MyDoctrineExtender implements DoctrineExtender
-{
-    /**
-     * @param Configuration $configuration
-     * @param Connection    $connection
-     * @param EventManager  $eventManager
-     */
-    public function extend(Configuration $configuration, Connection $connection, EventManager $eventManager)
-    {
-        (new DoctrineManagerTest)->assertExtendedCorrectly($configuration, $connection, $eventManager);
-    }
-}
-
-class InvalidDoctrineExtender
-{
 }

--- a/tests/Extensions/ExtensionManagerTest.php
+++ b/tests/Extensions/ExtensionManagerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Extensions;
+
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\EventManager;
 use Doctrine\Common\Persistence\ManagerRegistry;
@@ -8,12 +10,12 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Query\FilterCollection;
 use Illuminate\Contracts\Container\Container;
-use LaravelDoctrine\ORM\Extensions\Extension;
 use LaravelDoctrine\ORM\Extensions\ExtensionManager;
 use Mockery as m;
 use Mockery\Mock;
+use LaravelDoctrine\Tests\Mocks\ExtensionMock;
 
-class ExtensionManagerTest extends PHPUnit_Framework_TestCase
+class ExtensionManagerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Mock
@@ -97,7 +99,7 @@ class ExtensionManagerTest extends PHPUnit_Framework_TestCase
 
         // Should be inside booted extensions now
         $booted = $this->manager->getBootedExtensions();
-        $this->assertTrue($booted['default']['ExtensionMock']);
+        $this->assertTrue($booted['default'][ExtensionMock::class]);
     }
 
     public function test_boot_manager_with_two_managers_and_one_extension()
@@ -121,8 +123,8 @@ class ExtensionManagerTest extends PHPUnit_Framework_TestCase
 
         // Should be inside booted extensions now
         $booted = $this->manager->getBootedExtensions();
-        $this->assertTrue($booted['default']['ExtensionMock']);
-        $this->assertTrue($booted['custom']['ExtensionMock']);
+        $this->assertTrue($booted['default'][ExtensionMock::class]);
+        $this->assertTrue($booted['custom'][ExtensionMock::class]);
     }
 
     public function test_boot_manager_with_one_manager_and_two_extensions()
@@ -141,15 +143,15 @@ class ExtensionManagerTest extends PHPUnit_Framework_TestCase
         $this->container->shouldReceive('make')->with(ExtensionMock::class)->once()->andReturn(new ExtensionMock);
         $this->manager->register(ExtensionMock::class);
 
-        $this->container->shouldReceive('make')->with(ExtensionMock2::class)->once()->andReturn(new ExtensionMock2);
-        $this->manager->register(ExtensionMock2::class);
+        $this->container->shouldReceive('make')->with(\LaravelDoctrine\Tests\Mocks\ExtensionMock2::class)->once()->andReturn(new \LaravelDoctrine\Tests\Mocks\ExtensionMock2);
+        $this->manager->register(\LaravelDoctrine\Tests\Mocks\ExtensionMock2::class);
 
         $this->manager->boot($this->registry);
 
         // Should be inside booted extensions now
         $booted = $this->manager->getBootedExtensions();
-        $this->assertTrue($booted['default']['ExtensionMock']);
-        $this->assertTrue($booted['default']['ExtensionMock2']);
+        $this->assertTrue($booted['default'][ExtensionMock::class]);
+        $this->assertTrue($booted['default'][\LaravelDoctrine\Tests\Mocks\ExtensionMock2::class]);
     }
 
     public function test_extension_will_only_be_booted_once()
@@ -174,7 +176,7 @@ class ExtensionManagerTest extends PHPUnit_Framework_TestCase
 
         // Should be inside booted extensions now
         $booted = $this->manager->getBootedExtensions();
-        $this->assertTrue($booted['default']['ExtensionMock']);
+        $this->assertTrue($booted['default'][ExtensionMock::class]);
     }
 
     public function test_filters_get_registered_on_boot()
@@ -200,14 +202,14 @@ class ExtensionManagerTest extends PHPUnit_Framework_TestCase
         $collection->shouldReceive('enable')->once()->with('filter2');
 
         // Register
-        $this->container->shouldReceive('make')->with(ExtensionWithFiltersMock::class)->once()->andReturn(new ExtensionWithFiltersMock);
-        $this->manager->register(ExtensionWithFiltersMock::class);
+        $this->container->shouldReceive('make')->with(\LaravelDoctrine\Tests\Mocks\ExtensionWithFiltersMock::class)->once()->andReturn(new \LaravelDoctrine\Tests\Mocks\ExtensionWithFiltersMock);
+        $this->manager->register(\LaravelDoctrine\Tests\Mocks\ExtensionWithFiltersMock::class);
 
         $this->manager->boot($this->registry);
 
         // Should be inside booted extensions now
         $booted = $this->manager->getBootedExtensions();
-        $this->assertTrue($booted['default']['ExtensionWithFiltersMock']);
+        $this->assertTrue($booted['default'][\LaravelDoctrine\Tests\Mocks\ExtensionWithFiltersMock::class]);
     }
 
     protected function tearDown()
@@ -220,68 +222,5 @@ class ExtensionManagerTest extends PHPUnit_Framework_TestCase
     protected function newManager()
     {
         return new ExtensionManager($this->container);
-    }
-}
-
-class ExtensionMock implements Extension
-{
-    /**
-     * @param EventManager           $manager
-     * @param EntityManagerInterface $em
-     * @param Reader|null            $reader
-     */
-    public function addSubscribers(EventManager $manager, EntityManagerInterface $em, Reader $reader = null)
-    {
-        // Confirm it get's called
-        (new ExtensionManagerTest)->assertTrue(true);
-    }
-
-    /**
-     * @return array
-     */
-    public function getFilters()
-    {
-    }
-}
-
-class ExtensionMock2 implements Extension
-{
-    /**
-     * @param EventManager           $manager
-     * @param EntityManagerInterface $em
-     * @param Reader|null            $reader
-     */
-    public function addSubscribers(EventManager $manager, EntityManagerInterface $em, Reader $reader = null)
-    {
-    }
-
-    /**
-     * @return array
-     */
-    public function getFilters()
-    {
-    }
-}
-
-class ExtensionWithFiltersMock implements Extension
-{
-    /**
-     * @param EventManager           $manager
-     * @param EntityManagerInterface $em
-     * @param Reader|null            $reader
-     */
-    public function addSubscribers(EventManager $manager, EntityManagerInterface $em, Reader $reader = null)
-    {
-    }
-
-    /**
-     * @return array
-     */
-    public function getFilters()
-    {
-        return [
-            'filter'  => 'FilterMock',
-            'filter2' => 'FilterMock'
-        ];
     }
 }

--- a/tests/Extensions/MappingDriverChainTest.php
+++ b/tests/Extensions/MappingDriverChainTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Extensions;
+
 use Doctrine\Common\Persistence\Mapping\Driver\DefaultFileLocator;
 use Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
@@ -9,7 +11,7 @@ use LaravelDoctrine\ORM\Extensions\MappingDriverChain;
 use Mockery as m;
 use Mockery\Mock;
 
-class MappingDriverChainTest extends PHPUnit_Framework_TestCase
+class MappingDriverChainTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Mock

--- a/tests/Extensions/TablePrefix/TablePrefixExtensionTest.php
+++ b/tests/Extensions/TablePrefix/TablePrefixExtensionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Extensions\TablePrefix;
+
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
@@ -7,7 +9,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use LaravelDoctrine\ORM\Extensions\TablePrefix\TablePrefixExtension;
 use Mockery as m;
 
-class TablePrefixExtensionTest extends PHPUnit_Framework_TestCase
+class TablePrefixExtensionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Mockery\MockInterface

--- a/tests/Extensions/TablePrefix/TablePrefixListenerTest.php
+++ b/tests/Extensions/TablePrefix/TablePrefixListenerTest.php
@@ -1,11 +1,14 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Extensions\TablePrefix;
+
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use LaravelDoctrine\ORM\Extensions\TablePrefix\TablePrefixListener;
 use Mockery as m;
+use Doctrine\Common\Persistence\ObjectManager;
 
-class TablePrefixListenerTest extends PHPUnit_Framework_TestCase
+class TablePrefixListenerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var ClassMetadataInfo
@@ -25,9 +28,9 @@ class TablePrefixListenerTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->metadata = new ClassMetadataInfo('\Foo');
-        $this->metadata->setTableName('foo');
+        $this->metadata->setPrimaryTable(['name' => 'foo']);
 
-        $this->objectManager = m::mock('Doctrine\Common\Persistence\ObjectManager');
+        $this->objectManager = m::mock(ObjectManager::class);
         $this->args          = new LoadClassMetadataEventArgs($this->metadata, $this->objectManager);
     }
 

--- a/tests/IlluminateRegistryTest.php
+++ b/tests/IlluminateRegistryTest.php
@@ -1,15 +1,19 @@
 <?php
 
+namespace LaravelDoctrine\Tests;
+
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\ORMException;
 use Illuminate\Contracts\Container\Container;
+use InvalidArgumentException;
 use LaravelDoctrine\ORM\EntityManagerFactory;
 use LaravelDoctrine\ORM\IlluminateRegistry;
 use Mockery as m;
 use Mockery\Mock;
+use stdClass;
 
-class IlluminateRegistryTest extends PHPUnit_Framework_TestCase
+class IlluminateRegistryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Mock
@@ -106,10 +110,8 @@ class IlluminateRegistryTest extends PHPUnit_Framework_TestCase
 
     public function test_cannot_non_existing_connection()
     {
-        $this->setExpectedException(
-            InvalidArgumentException::class,
-            'Doctrine Connection named "non-existing" does not exist.'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Doctrine Connection named "non-existing" does not exist.');
 
         $this->registry->getConnection('non-existing');
     }
@@ -202,10 +204,8 @@ class IlluminateRegistryTest extends PHPUnit_Framework_TestCase
 
     public function test_cannot_non_existing_manager()
     {
-        $this->setExpectedException(
-            InvalidArgumentException::class,
-            'Doctrine Manager named "non-existing" does not exist.'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Doctrine Manager named "non-existing" does not exist.');
 
         $this->registry->getManager('non-existing');
     }
@@ -333,30 +333,24 @@ class IlluminateRegistryTest extends PHPUnit_Framework_TestCase
 
     public function test_cannot_purge_non_existing_managers()
     {
-        $this->setExpectedException(
-            InvalidArgumentException::class,
-            'Doctrine Manager named "non-existing" does not exist.'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Doctrine Manager named "non-existing" does not exist.');
 
         $this->registry->purgeManager('non-existing');
     }
 
     public function test_cannot_reset_non_existing_managers()
     {
-        $this->setExpectedException(
-            InvalidArgumentException::class,
-            'Doctrine Manager named "non-existing" does not exist.'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Doctrine Manager named "non-existing" does not exist.');
 
         $this->registry->resetManager('non-existing');
     }
 
     public function test_get_alias_namespace_from_unknown_namespace()
     {
-        $this->setExpectedException(
-            ORMException::class,
-            'Unknown Entity namespace alias \'Alias\''
-        );
+        $this->expectException(ORMException::class);
+        $this->expectExceptionMessage('Unknown Entity namespace alias \'Alias\'');
 
         $this->registry->getAliasNamespace('Alias');
     }

--- a/tests/Loggers/Clockwork/DoctrineDataSourceTest.php
+++ b/tests/Loggers/Clockwork/DoctrineDataSourceTest.php
@@ -1,12 +1,14 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Loggers\Clockwork;
+
 use Clockwork\Request\Request;
 use Doctrine\DBAL\Logging\DebugStack;
 use LaravelDoctrine\ORM\Loggers\Clockwork\DoctrineDataSource;
 use Mockery as m;
 use Mockery\Mock;
 
-class DoctrineDataSourceTest extends PHPUnit_Framework_TestCase
+class DoctrineDataSourceTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var DebugStack
@@ -19,7 +21,7 @@ class DoctrineDataSourceTest extends PHPUnit_Framework_TestCase
     protected $source;
 
     /**
-     * @var Doctrine\DBAL\Connection
+     * @var \Doctrine\DBAL\Connection
      */
     protected $connection;
 

--- a/tests/Loggers/ClockworkLoggerTest.php
+++ b/tests/Loggers/ClockworkLoggerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Loggers;
+
 use Clockwork\Clockwork;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
@@ -8,7 +10,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use LaravelDoctrine\ORM\Loggers\ClockworkLogger;
 use Mockery as m;
 
-class ClockworkLoggerTest extends PHPUnit_Framework_TestCase
+class ClockworkLoggerTest extends \PHPUnit\Framework\TestCase
 {
     public function test_can_register()
     {

--- a/tests/Loggers/EchoLoggerTest.php
+++ b/tests/Loggers/EchoLoggerTest.php
@@ -1,11 +1,13 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Loggers;
+
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use LaravelDoctrine\ORM\Loggers\EchoLogger;
 use Mockery as m;
 
-class EchoLoggerTest extends PHPUnit_Framework_TestCase
+class EchoLoggerTest extends \PHPUnit\Framework\TestCase
 {
     public function test_can_register()
     {

--- a/tests/Loggers/File/DoctrineFileLoggerTest.php
+++ b/tests/Loggers/File/DoctrineFileLoggerTest.php
@@ -1,12 +1,14 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Loggers\File;
+
 use Doctrine\DBAL\Connection;
 use LaravelDoctrine\ORM\Loggers\File\DoctrineFileLogger;
 use Mockery as m;
 use Mockery\Mock;
 use Psr\Log\LoggerInterface as Log;
 
-class DoctrineFileLoggerTest extends PHPUnit_Framework_TestCase
+class DoctrineFileLoggerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var DoctrineFileLogger

--- a/tests/Loggers/FileLoggerTest.php
+++ b/tests/Loggers/FileLoggerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Loggers;
+
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
@@ -7,7 +9,7 @@ use LaravelDoctrine\ORM\Loggers\FileLogger;
 use Mockery as m;
 use Psr\Log\LoggerInterface as Log;
 
-class FileLoggerTest extends PHPUnit_Framework_TestCase
+class FileLoggerTest extends \PHPUnit\Framework\TestCase
 {
     public function test_can_register()
     {

--- a/tests/Loggers/Formatters/FormatQueryKeywordsTest.php
+++ b/tests/Loggers/Formatters/FormatQueryKeywordsTest.php
@@ -1,12 +1,14 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Loggers\Formatters;
+
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use LaravelDoctrine\ORM\Loggers\Formatters\FormatQueryKeywords;
 use LaravelDoctrine\ORM\Loggers\Formatters\QueryFormatter;
 use Mockery as m;
 use Mockery\Mock;
 
-class FormatQueryKeywordsTest extends PHPUnit_Framework_TestCase
+class FormatQueryKeywordsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Mock
@@ -31,7 +33,7 @@ class FormatQueryKeywordsTest extends PHPUnit_Framework_TestCase
 
     public function test_formats_select_queries()
     {
-        $sql    = "select * from table where condition is not null having count(id) > 10 limit 10 offset 10 group by parent order by position desc";
+        $sql    = 'select * from table where condition is not null having count(id) > 10 limit 10 offset 10 group by parent order by position desc';
         $params = [];
         $types  = [];
 
@@ -42,7 +44,7 @@ class FormatQueryKeywordsTest extends PHPUnit_Framework_TestCase
 
     public function test_formats_insert_queries()
     {
-        $sql    = "insert into table (column1, column2, column3) values (value1, value2, value3)";
+        $sql    = 'insert into table (column1, column2, column3) values (value1, value2, value3)';
         $params = [];
         $types  = [];
 
@@ -53,7 +55,7 @@ class FormatQueryKeywordsTest extends PHPUnit_Framework_TestCase
 
     public function test_formats_update_queries()
     {
-        $sql    = "update table set column1=value, column2=value2 where some_column=some_value";
+        $sql    = 'update table set column1=value, column2=value2 where some_column=some_value';
         $params = [];
         $types  = [];
 
@@ -64,7 +66,7 @@ class FormatQueryKeywordsTest extends PHPUnit_Framework_TestCase
 
     public function test_formats_delete_queries()
     {
-        $sql    = "update table set column1=value, column2=value2 where some_column=some_value";
+        $sql    = 'update table set column1=value, column2=value2 where some_column=some_value';
         $params = [];
         $types  = [];
 

--- a/tests/Loggers/LaravelDebugbarLoggerTest.php
+++ b/tests/Loggers/LaravelDebugbarLoggerTest.php
@@ -1,12 +1,14 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Loggers;
+
 use Barryvdh\Debugbar\LaravelDebugbar;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use LaravelDoctrine\ORM\Loggers\LaravelDebugbarLogger;
 use Mockery as m;
 
-class LaravelDebugbarLoggerTest extends PHPUnit_Framework_TestCase
+class LaravelDebugbarLoggerTest extends \PHPUnit\Framework\TestCase
 {
     public function test_can_register()
     {

--- a/tests/Mocks/AnotherListenerStub.php
+++ b/tests/Mocks/AnotherListenerStub.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+class AnotherListenerStub
+{
+}

--- a/tests/Mocks/ArrayableEntity.php
+++ b/tests/Mocks/ArrayableEntity.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+use LaravelDoctrine\ORM\Serializers\Arrayable;
+
+class ArrayableEntity
+{
+    use Arrayable;
+
+    protected $id = 'IDVALUE';
+
+    protected $name = 'NAMEVALUE';
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/tests/Mocks/AuthenticatableMock.php
+++ b/tests/Mocks/AuthenticatableMock.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
+use LaravelDoctrine\ORM\Auth\Authenticatable;
+
+class AuthenticatableMock implements AuthenticatableContract
+{
+    use Authenticatable;
+
+    public function __construct()
+    {
+        $this->password = 'myPassword';
+    }
+}

--- a/tests/Mocks/AuthenticatableWithNonEmptyConstructorMock.php
+++ b/tests/Mocks/AuthenticatableWithNonEmptyConstructorMock.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
+use LaravelDoctrine\ORM\Auth\Authenticatable;
+
+class AuthenticatableWithNonEmptyConstructorMock implements AuthenticatableContract
+{
+    use Authenticatable;
+
+    public function __construct(array $passwords)
+    {
+        $this->password = $passwords[0];
+    }
+}

--- a/tests/Mocks/BaseHydrateableClass.php
+++ b/tests/Mocks/BaseHydrateableClass.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+class BaseHydrateableClass
+{
+    private $name;
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/tests/Mocks/BindableEntity.php
+++ b/tests/Mocks/BindableEntity.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+class BindableEntity
+{
+    public $id;
+
+    public $name;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return strtolower($this->name);
+    }
+}

--- a/tests/Mocks/BindableEntityWithInterface.php
+++ b/tests/Mocks/BindableEntityWithInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+class BindableEntityWithInterface implements \LaravelDoctrine\ORM\Contracts\UrlRoutable
+{
+    public $id;
+
+    public $name;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return strtolower($this->name);
+    }
+
+    public static function getRouteKeyName(): string
+    {
+        return 'name';
+    }
+}

--- a/tests/Mocks/ChildHydrateableClass.php
+++ b/tests/Mocks/ChildHydrateableClass.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+class ChildHydrateableClass extends BaseHydrateableClass
+{
+    private $description;
+
+    public function getDescription()
+    {
+        return $this->description;
+    }
+}

--- a/tests/Mocks/CountableEntityMock.php
+++ b/tests/Mocks/CountableEntityMock.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+class CountableEntityMock
+{
+}

--- a/tests/Mocks/CustomNotifiableStub.php
+++ b/tests/Mocks/CustomNotifiableStub.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+use LaravelDoctrine\ORM\Notifications\Notifiable;
+
+class CustomNotifiableStub
+{
+    use Notifiable;
+
+    public function routeNotificationForDoctrine()
+    {
+        return 'custom';
+    }
+}

--- a/tests/Mocks/Decorator.php
+++ b/tests/Mocks/Decorator.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+use Doctrine\ORM\Decorator\EntityManagerDecorator;
+
+class Decorator extends EntityManagerDecorator
+{
+}

--- a/tests/Mocks/EntityController.php
+++ b/tests/Mocks/EntityController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+class EntityController
+{
+    public function index(BindableEntity $entity)
+    {
+        return $entity->getName();
+    }
+
+    public function interfacer(BindableEntityWithInterface $entity)
+    {
+        return $entity->getId();
+    }
+}

--- a/tests/Mocks/EntityStub.php
+++ b/tests/Mocks/EntityStub.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+/**
+ * @Entity
+ */
+class EntityStub
+{
+    /**
+     * @Id @GeneratedValue @Column(type="integer")
+     */
+    public $id;
+
+    /**
+     * @Column(type="string")
+     */
+    public $name;
+
+    /**
+     * @ManyToMany(targetEntity="EntityStub")
+     * @JoinTable(name="stub_stubs",
+     *      joinColumns={@JoinColumn(name="owner_id", referencedColumnName="id")},
+     *      inverseJoinColumns={@JoinColumn(name="owned_id", referencedColumnName="id")}
+     * )
+     */
+    public $others;
+}

--- a/tests/Mocks/ExtensionMock.php
+++ b/tests/Mocks/ExtensionMock.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\Common\EventManager;
+use Doctrine\ORM\EntityManagerInterface;
+use LaravelDoctrine\ORM\Extensions\Extension;
+use LaravelDoctrine\Tests\Extensions\ExtensionManagerTest;
+
+class ExtensionMock implements Extension
+{
+    /**
+     * @param EventManager $manager
+     * @param EntityManagerInterface $em
+     * @param Reader|null $reader
+     */
+    public function addSubscribers(EventManager $manager, EntityManagerInterface $em, Reader $reader = null)
+    {
+        // Confirm it get's called
+        ExtensionManagerTest::assertTrue(true);
+    }
+
+    public function getFilters()
+    {
+    }
+}

--- a/tests/Mocks/ExtensionMock2.php
+++ b/tests/Mocks/ExtensionMock2.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\Common\EventManager;
+use Doctrine\ORM\EntityManagerInterface;
+use LaravelDoctrine\ORM\Extensions\Extension;
+
+class ExtensionMock2 implements Extension
+{
+    /**
+     * @param EventManager $manager
+     * @param EntityManagerInterface $em
+     * @param Reader|null $reader
+     */
+    public function addSubscribers(EventManager $manager, EntityManagerInterface $em, Reader $reader = null)
+    {
+    }
+
+    public function getFilters()
+    {
+    }
+}

--- a/tests/Mocks/ExtensionWithFiltersMock.php
+++ b/tests/Mocks/ExtensionWithFiltersMock.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+use Doctrine\Common\Annotations\Reader;
+use Doctrine\Common\EventManager;
+use Doctrine\ORM\EntityManagerInterface;
+use LaravelDoctrine\ORM\Extensions\Extension;
+
+class ExtensionWithFiltersMock implements Extension
+{
+    /**
+     * @param EventManager $manager
+     * @param EntityManagerInterface $em
+     * @param Reader|null $reader
+     */
+    public function addSubscribers(EventManager $manager, EntityManagerInterface $em, Reader $reader = null)
+    {
+    }
+
+    /**
+     * @return array
+     */
+    public function getFilters()
+    {
+        return [
+            'filter' => 'FilterMock',
+            'filter2' => 'FilterMock',
+        ];
+    }
+}

--- a/tests/Mocks/FilterStub.php
+++ b/tests/Mocks/FilterStub.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+class FilterStub
+{
+}

--- a/tests/Mocks/Foo.php
+++ b/tests/Mocks/Foo.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+class Foo
+{
+    private $id;
+
+    private $name;
+}

--- a/tests/Mocks/InvalidDoctrineExtender.php
+++ b/tests/Mocks/InvalidDoctrineExtender.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+class InvalidDoctrineExtender
+{
+}

--- a/tests/Mocks/JsonableEntity.php
+++ b/tests/Mocks/JsonableEntity.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+use LaravelDoctrine\ORM\Serializers\Jsonable;
+
+class JsonableEntity
+{
+    use Jsonable;
+
+    protected $id = 'IDVALUE';
+
+    protected $name = 'NAMEVALUE';
+
+    protected $numeric = '1';
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getNumeric()
+    {
+        return $this->numeric;
+    }
+}

--- a/tests/Mocks/ListenerStub.php
+++ b/tests/Mocks/ListenerStub.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+class ListenerStub
+{
+}

--- a/tests/Mocks/MyDoctrineExtender.php
+++ b/tests/Mocks/MyDoctrineExtender.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+use Doctrine\Common\EventManager;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\Configuration;
+use LaravelDoctrine\ORM\DoctrineExtender;
+use LaravelDoctrine\Tests\DoctrineManagerTest;
+
+class MyDoctrineExtender implements DoctrineExtender
+{
+    /**
+     * @param Configuration $configuration
+     * @param Connection $connection
+     * @param EventManager $eventManager
+     */
+    public function extend(Configuration $configuration, Connection $connection, EventManager $eventManager)
+    {
+        (new DoctrineManagerTest)->assertExtendedCorrectly($configuration, $connection, $eventManager);
+    }
+}

--- a/tests/Mocks/NotifiableStub.php
+++ b/tests/Mocks/NotifiableStub.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+use LaravelDoctrine\ORM\Notifications\Notifiable;
+
+class NotifiableStub
+{
+    use Notifiable;
+}

--- a/tests/Mocks/NotificationStub.php
+++ b/tests/Mocks/NotificationStub.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+use Illuminate\Notifications\Notification as IlluminateNotification;
+use LaravelDoctrine\ORM\Notifications\Notification as LaravelDoctrineNotification;
+
+class NotificationStub extends IlluminateNotification
+{
+    public function toEntity()
+    {
+        return new LaravelDoctrineNotification;
+    }
+}

--- a/tests/Mocks/ObjectClass.php
+++ b/tests/Mocks/ObjectClass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+class ObjectClass
+{
+    public $status = false;
+}

--- a/tests/Mocks/ObjectType.php
+++ b/tests/Mocks/ObjectType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\JsonType;
+
+class ObjectType extends JsonType
+{
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        return json_encode(get_object_vars($value));
+    }
+
+    public function getName()
+    {
+        return 'object_type';
+    }
+}

--- a/tests/Mocks/StringClass.php
+++ b/tests/Mocks/StringClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+class StringClass
+{
+    public function __toString()
+    {
+        return 'string';
+    }
+}

--- a/tests/Mocks/SubscriberStub.php
+++ b/tests/Mocks/SubscriberStub.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+use Doctrine\Common\EventSubscriber;
+
+class SubscriberStub implements EventSubscriber
+{
+    /**
+     * Returns an array of events this subscriber wants to listen to.
+     * @return array
+     */
+    public function getSubscribedEvents()
+    {
+        return [
+            'onFlush',
+        ];
+    }
+}

--- a/tests/Mocks/TypeMock.php
+++ b/tests/Mocks/TypeMock.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+class TypeMock
+{
+}

--- a/tests/Mocks/TypeMock2.php
+++ b/tests/Mocks/TypeMock2.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+class TypeMock2
+{
+}

--- a/tests/Mocks/UserMock.php
+++ b/tests/Mocks/UserMock.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace LaravelDoctrine\Tests\Mocks;
+
+use Illuminate\Contracts\Auth\CanResetPassword;
+
+class UserMock implements CanResetPassword
+{
+    /**
+     * Get the e-mail address where password reset links are sent.
+     * @return string
+     */
+    public function getEmailForPasswordReset()
+    {
+        return 'user@mockery.mock';
+    }
+
+    /**
+     * Send the password reset notification.
+     *
+     * @param  string $token
+     * @return void
+     */
+    public function sendPasswordResetNotification($token)
+    {
+        // TODO: Implement sendPasswordResetNotification() method.
+    }
+}

--- a/tests/Notifications/DoctrineChannelTest.php
+++ b/tests/Notifications/DoctrineChannelTest.php
@@ -1,13 +1,17 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Notifications;
+
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManagerInterface;
 use LaravelDoctrine\ORM\Exceptions\NoEntityManagerFound;
 use LaravelDoctrine\ORM\Notifications\DoctrineChannel;
-use LaravelDoctrine\ORM\Notifications\Notifiable;
+use LaravelDoctrine\Tests\Mocks\NotificationStub;
+use Mockery;
 use Mockery\Mock;
+use LaravelDoctrine\ORM\Notifications\Notification;
 
-class DoctrineChannelTest extends PHPUnit_Framework_TestCase
+class DoctrineChannelTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var DoctrineChannel
@@ -36,10 +40,10 @@ class DoctrineChannelTest extends PHPUnit_Framework_TestCase
     public function test_can_send_notification_on_default_em()
     {
         $this->registry->shouldReceive('getManagerForClass')
-                       ->with('LaravelDoctrine\ORM\Notifications\Notification')
+                       ->with(Notification::class)
                        ->andReturn($this->em);
 
-        $this->channel->send(new NotifiableStub, new NotificationStub);
+        $this->channel->send(new \LaravelDoctrine\Tests\Mocks\NotifiableStub, new NotificationStub);
 
         $this->em->shouldHaveReceived('persist')->once();
         $this->em->shouldHaveReceived('flush')->once();
@@ -51,7 +55,7 @@ class DoctrineChannelTest extends PHPUnit_Framework_TestCase
                        ->with('custom')
                        ->andReturn($this->em);
 
-        $this->channel->send(new CustomNotifiableStub, new NotificationStub);
+        $this->channel->send(new \LaravelDoctrine\Tests\Mocks\CustomNotifiableStub, new NotificationStub);
 
         $this->em->shouldHaveReceived('persist')->once();
         $this->em->shouldHaveReceived('flush')->once();
@@ -59,35 +63,12 @@ class DoctrineChannelTest extends PHPUnit_Framework_TestCase
 
     public function test_it_should_throw_exception_when_it_does_not_find_an_em()
     {
-        $this->setExpectedException(NoEntityManagerFound::class);
+        $this->expectException(NoEntityManagerFound::class);
 
         $this->registry->shouldReceive('getManager')
                        ->with('custom')
                        ->andReturnNull();
 
-        $this->channel->send(new CustomNotifiableStub, new NotificationStub);
-    }
-}
-
-class NotificationStub extends \Illuminate\Notifications\Notification
-{
-    public function toEntity()
-    {
-        return (new \LaravelDoctrine\ORM\Notifications\Notification);
-    }
-}
-
-class NotifiableStub
-{
-    use Notifiable;
-}
-
-class CustomNotifiableStub
-{
-    use Notifiable;
-
-    public function routeNotificationForDoctrine()
-    {
-        return 'custom';
+        $this->channel->send(new \LaravelDoctrine\Tests\Mocks\CustomNotifiableStub, new NotificationStub);
     }
 }

--- a/tests/Pagination/PaginatorAdapterTest.php
+++ b/tests/Pagination/PaginatorAdapterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Pagination;
+
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
@@ -13,12 +15,12 @@ use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\AbstractPaginator;
 use LaravelDoctrine\ORM\Pagination\PaginatorAdapter;
 
-class PaginatorAdapterTest extends PHPUnit_Framework_TestCase
+class PaginatorAdapterTest extends \PHPUnit\Framework\TestCase
 {
     public function testMakesLaravelsPaginatorFromParams()
     {
         $em      = $this->mockEntityManager();
-        $query   = (new Query($em))->setDQL('SELECT f FROM Foo f');
+        $query   = (new Query($em))->setDQL('SELECT f FROM LaravelDoctrine\Tests\Mocks\Foo f');
         $adapter = PaginatorAdapter::fromParams($query, 15, 2);
 
         $paginator = $adapter->make();
@@ -34,7 +36,7 @@ class PaginatorAdapterTest extends PHPUnit_Framework_TestCase
         });
 
         $em      = $this->mockEntityManager();
-        $query   = (new Query($em))->setDQL('SELECT f FROM Foo f');
+        $query   = (new Query($em))->setDQL('SELECT f FROM LaravelDoctrine\Tests\Mocks\Foo f');
         $adapter = PaginatorAdapter::fromRequest($query);
 
         $paginator = $adapter->make();
@@ -77,7 +79,7 @@ class PaginatorAdapterTest extends PHPUnit_Framework_TestCase
         ];
 
         $metadata->subClasses                = [];
-        $metadata->name                      = 'Foo';
+        $metadata->name                      = \LaravelDoctrine\Tests\Mocks\Foo::class;
         $metadata->containsForeignIdentifier = false;
         $metadata->identifier                = ['id'];
 
@@ -106,18 +108,11 @@ class PaginatorAdapterTest extends PHPUnit_Framework_TestCase
         $hydrator->shouldReceive('hydrateAll')->andReturn([]);
 
         $em->shouldReceive('getConfiguration')->andReturn($config);
-        $em->shouldReceive('getClassMetadata')->with('Foo')->andReturn($metadata);
+        $em->shouldReceive('getClassMetadata')->with(\LaravelDoctrine\Tests\Mocks\Foo::class)->andReturn($metadata);
         $em->shouldReceive('getConnection')->andReturn($connection);
         $em->shouldReceive('hasFilters')->andReturn(false);
         $em->shouldReceive('newHydrator')->andReturn($hydrator);
 
         return $em;
     }
-}
-
-class Foo
-{
-    private $id;
-
-    private $name;
 }

--- a/tests/Resolvers/EntityListenerResolverTest.php
+++ b/tests/Resolvers/EntityListenerResolverTest.php
@@ -1,11 +1,16 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Resolvers;
+
+
 use Doctrine\ORM\Mapping\EntityListenerResolver as ResolverContract;
 use Illuminate\Contracts\Container\Container;
+use InvalidArgumentException;
 use LaravelDoctrine\ORM\Resolvers\EntityListenerResolver;
 use Mockery as m;
+use stdClass;
 
-class EntityListenerResolverTest extends PHPUnit_Framework_TestCase
+class EntityListenerResolverTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var m\MockInterface|Container
@@ -99,12 +104,12 @@ class EntityListenerResolverTest extends PHPUnit_Framework_TestCase
 
         $resolvedObject = $this->resolver->resolve(get_class($object));
 
-        $this->assertSame($object, $resolvedObject, "Resolver should not use container when directly registering");
+        $this->assertSame($object, $resolvedObject, 'Resolver should not use container when directly registering');
     }
 
     public function testDoesNotAllowRegisteringNonObjects()
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->resolver->register('foo');
     }
 }

--- a/tests/Serializers/ArraySerializerTest.php
+++ b/tests/Serializers/ArraySerializerTest.php
@@ -1,9 +1,10 @@
 <?php
 
-use LaravelDoctrine\ORM\Serializers\Arrayable;
+namespace LaravelDoctrine\Tests\Serializers;
+
 use LaravelDoctrine\ORM\Serializers\ArraySerializer;
 
-class ArraySerializerTest extends PHPUnit_Framework_TestCase
+class ArraySerializerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var ArraySerializer
@@ -17,30 +18,11 @@ class ArraySerializerTest extends PHPUnit_Framework_TestCase
 
     public function test_can_serialize_to_array()
     {
-        $array = $this->serializer->serialize(new ArrayableEntity);
+        $array = $this->serializer->serialize(new \LaravelDoctrine\Tests\Mocks\ArrayableEntity);
 
         $this->assertEquals([
             'id'   => 'IDVALUE',
             'name' => 'NAMEVALUE'
         ], $array);
-    }
-}
-
-class ArrayableEntity
-{
-    use Arrayable;
-
-    protected $id = 'IDVALUE';
-
-    protected $name = 'NAMEVALUE';
-
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    public function getName()
-    {
-        return $this->name;
     }
 }

--- a/tests/Serializers/JsonSerializerTest.php
+++ b/tests/Serializers/JsonSerializerTest.php
@@ -1,9 +1,10 @@
 <?php
 
-use LaravelDoctrine\ORM\Serializers\Jsonable;
+namespace LaravelDoctrine\Tests\Serializers;
+
 use LaravelDoctrine\ORM\Serializers\JsonSerializer;
 
-class JsonSerializerTest extends PHPUnit_Framework_TestCase
+class JsonSerializerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var JsonSerializer
@@ -17,7 +18,7 @@ class JsonSerializerTest extends PHPUnit_Framework_TestCase
 
     public function test_can_serialize_to_json()
     {
-        $json = $this->serializer->serialize(new JsonableEntity);
+        $json = $this->serializer->serialize(new \LaravelDoctrine\Tests\Mocks\JsonableEntity);
 
         $this->assertJson($json);
         $this->assertEquals('{"id":"IDVALUE","name":"NAMEVALUE","numeric":"1"}', $json);
@@ -25,35 +26,9 @@ class JsonSerializerTest extends PHPUnit_Framework_TestCase
 
     public function test_can_serialize_to_json_with_numeric_check()
     {
-        $json = $this->serializer->serialize(new JsonableEntity(), JSON_NUMERIC_CHECK);
+        $json = $this->serializer->serialize(new \LaravelDoctrine\Tests\Mocks\JsonableEntity(), JSON_NUMERIC_CHECK);
 
         $this->assertJson($json);
         $this->assertEquals('{"id":"IDVALUE","name":"NAMEVALUE","numeric":1}', $json);
-    }
-}
-
-class JsonableEntity
-{
-    use Jsonable;
-
-    protected $id = 'IDVALUE';
-
-    protected $name = 'NAMEVALUE';
-
-    protected $numeric = "1";
-
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    public function getNumeric()
-    {
-        return $this->numeric;
     }
 }

--- a/tests/Stubs/Faker/Generator.php
+++ b/tests/Stubs/Faker/Generator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Faker;
+namespace LaravelDoctrine\Tests\Stubs\Faker;
 
 interface Generator
 {

--- a/tests/Testing/FactoryTest.php
+++ b/tests/Testing/FactoryTest.php
@@ -1,15 +1,19 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Testing;
+
 use Doctrine\Common\Persistence\ManagerRegistry;
 use LaravelDoctrine\ORM\Testing\Factory;
+use LaravelDoctrine\Tests\Stubs\Faker\Generator;
+use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 class FactoryTest extends MockeryTestCase
 {
     public function test_it_passes_along_the_class_configured_states()
     {
-        /** @var Faker\Generator $faker */
-        $faker = Mockery::mock(Faker\Generator::class);
+        /** @var Generator $faker */
+        $faker = Mockery::mock(Generator::class);
         /** @var ManagerRegistry $registry */
         $registry = Mockery::mock(ManagerRegistry::class);
 
@@ -18,6 +22,7 @@ class FactoryTest extends MockeryTestCase
         });
 
         $builder = $factory->of('SomeClass');
+        //todo this https://github.com/symfony/symfony/pull/29686 will help to move when phpunit 8 is done
         $this->assertAttributeEquals(['withState' => function () {
         }], 'states', $builder);
     }

--- a/tests/Testing/SimpleHydratorTest.php
+++ b/tests/Testing/SimpleHydratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Testing;
+
 use LaravelDoctrine\ORM\Testing\SimpleHydrator;
 use PHPUnit\Framework\TestCase;
 
@@ -7,43 +9,23 @@ class SimpleHydratorTest extends TestCase
 {
     public function test_can_hydrate_class()
     {
-        $entity = SimpleHydrator::hydrate(BaseHydrateableClass::class, [
+        $entity = SimpleHydrator::hydrate(\LaravelDoctrine\Tests\Mocks\BaseHydrateableClass::class, [
             'name' => 'Patrick',
         ]);
 
-        $this->assertInstanceOf(BaseHydrateableClass::class, $entity);
+        $this->assertInstanceOf(\LaravelDoctrine\Tests\Mocks\BaseHydrateableClass::class, $entity);
         $this->assertEquals('Patrick', $entity->getName());
     }
 
     public function test_can_hydrate_with_extension_of_private_properties()
     {
-        $entity = SimpleHydrator::hydrate(ChildHydrateableClass::class, [
+        $entity = SimpleHydrator::hydrate(\LaravelDoctrine\Tests\Mocks\ChildHydrateableClass::class, [
             'name'        => 'Patrick',
             'description' => 'Hello World',
         ]);
 
-        $this->assertInstanceOf(ChildHydrateableClass::class, $entity);
+        $this->assertInstanceOf(\LaravelDoctrine\Tests\Mocks\ChildHydrateableClass::class, $entity);
         $this->assertEquals('Patrick', $entity->getName());
         $this->assertEquals('Hello World', $entity->getDescription());
-    }
-}
-
-class ChildHydrateableClass extends BaseHydrateableClass
-{
-    private $description;
-
-    public function getDescription()
-    {
-        return $this->description;
-    }
-}
-
-class BaseHydrateableClass
-{
-    private $name;
-
-    public function getName()
-    {
-        return $this->name;
     }
 }

--- a/tests/Types/JsonTypeTest.php
+++ b/tests/Types/JsonTypeTest.php
@@ -1,12 +1,14 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Types;
+
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use LaravelDoctrine\ORM\Types\Json;
 use Mockery as m;
 use Mockery\Mock;
 
-class JsonTypeTest extends PHPUnit_Framework_TestCase
+class JsonTypeTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Json

--- a/tests/Utilities/ArrayUtilTest.php
+++ b/tests/Utilities/ArrayUtilTest.php
@@ -1,8 +1,10 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Utilities;
+
 use LaravelDoctrine\ORM\Utilities\ArrayUtil;
 
-class ArrayUtilTest extends PHPUnit_Framework_TestCase
+class ArrayUtilTest extends \PHPUnit\Framework\TestCase
 {
     public function test_returns_value_when_exists()
     {

--- a/tests/Validation/DoctrinePresenceVerifierTest.php
+++ b/tests/Validation/DoctrinePresenceVerifierTest.php
@@ -1,14 +1,17 @@
 <?php
 
+namespace LaravelDoctrine\Tests\Validation;
+
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
+use InvalidArgumentException;
 use LaravelDoctrine\ORM\Validation\DoctrinePresenceVerifier;
 use Mockery as m;
 use Mockery\Mock;
 
-class DoctrinePresenceVerifierTest extends PHPUnit_Framework_TestCase
+class DoctrinePresenceVerifierTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Mock
@@ -51,7 +54,7 @@ class DoctrinePresenceVerifierTest extends PHPUnit_Framework_TestCase
     {
         $this->defaultGetCountMocks();
 
-        $this->verifier->getCount(CountableEntityMock::class, 'email', 'test@email.com');
+        $this->verifier->getCount(\LaravelDoctrine\Tests\Mocks\CountableEntityMock::class, 'email', 'test@email.com');
     }
 
     public function test_can_get_count_with_excluded_ids()
@@ -63,7 +66,7 @@ class DoctrinePresenceVerifierTest extends PHPUnit_Framework_TestCase
 
         $this->query->shouldReceive('setParameter')->once()->with('id', 1);
 
-        $this->verifier->getCount(CountableEntityMock::class, 'email', 'test@email.com', 1);
+        $this->verifier->getCount(\LaravelDoctrine\Tests\Mocks\CountableEntityMock::class, 'email', 'test@email.com', 1);
     }
 
     public function test_can_get_count_with_excluded_ids_with_custom_id_column()
@@ -75,7 +78,7 @@ class DoctrinePresenceVerifierTest extends PHPUnit_Framework_TestCase
 
         $this->query->shouldReceive('setParameter')->once()->with('new_id', 1);
 
-        $this->verifier->getCount(CountableEntityMock::class, 'email', 'test@email.com', 1, 'new_id');
+        $this->verifier->getCount(\LaravelDoctrine\Tests\Mocks\CountableEntityMock::class, 'email', 'test@email.com', 1, 'new_id');
     }
 
     public function test_can_get_count_with_extra_conditions()
@@ -95,7 +98,7 @@ class DoctrinePresenceVerifierTest extends PHPUnit_Framework_TestCase
         $this->builder->shouldReceive('setParameter')->once()->with('condition2', 'value2');
         $this->builder->shouldReceive('setParameter')->once()->with('condition3', 'value3');
 
-        $this->verifier->getCount(CountableEntityMock::class, 'email', 'test@email.com', null, null, [
+        $this->verifier->getCount(\LaravelDoctrine\Tests\Mocks\CountableEntityMock::class, 'email', 'test@email.com', null, null, [
             'condition1' => 'value1',
             'condition2' => 'value2',
             'condition3' => '!value3'
@@ -118,7 +121,7 @@ class DoctrinePresenceVerifierTest extends PHPUnit_Framework_TestCase
         $this->builder->shouldReceive('setParameter')->once()->with('condition1', 'value1');
         $this->builder->shouldReceive('setParameter')->once()->with('condition2', 'value2');
 
-        $this->verifier->getCount(CountableEntityMock::class, 'email', 'test@email.com', null, null, [
+        $this->verifier->getCount(\LaravelDoctrine\Tests\Mocks\CountableEntityMock::class, 'email', 'test@email.com', null, null, [
             'condition1' => 'value1',
             'condition2' => 'value2',
             'condition3' => 'NULL'
@@ -141,7 +144,7 @@ class DoctrinePresenceVerifierTest extends PHPUnit_Framework_TestCase
         $this->builder->shouldReceive('setParameter')->once()->with('condition1', 'value1');
         $this->builder->shouldReceive('setParameter')->once()->with('condition2', 'value2');
 
-        $this->verifier->getCount(CountableEntityMock::class, 'email', 'test@email.com', null, null, [
+        $this->verifier->getCount(\LaravelDoctrine\Tests\Mocks\CountableEntityMock::class, 'email', 'test@email.com', null, null, [
             'condition1' => 'value1',
             'condition2' => 'value2',
             'condition3' => 'NOT_NULL'
@@ -152,7 +155,7 @@ class DoctrinePresenceVerifierTest extends PHPUnit_Framework_TestCase
     {
         $this->defaultGetMultiCountMocks();
 
-        $this->verifier->getMultiCount(CountableEntityMock::class, 'email', ['test@email.com']);
+        $this->verifier->getMultiCount(\LaravelDoctrine\Tests\Mocks\CountableEntityMock::class, 'email', ['test@email.com']);
     }
 
     public function test_can_get_multi_count_with_extra_conditions()
@@ -168,7 +171,7 @@ class DoctrinePresenceVerifierTest extends PHPUnit_Framework_TestCase
         $this->builder->shouldReceive('setParameter')->once()->with('condition1', 'value1');
         $this->builder->shouldReceive('setParameter')->once()->with('condition2', 'value2');
 
-        $this->verifier->getMultiCount(CountableEntityMock::class, 'email', ['test@email.com'], [
+        $this->verifier->getMultiCount(\LaravelDoctrine\Tests\Mocks\CountableEntityMock::class, 'email', ['test@email.com'], [
             'condition1' => 'value1',
             'condition2' => 'value2'
         ]);
@@ -177,19 +180,19 @@ class DoctrinePresenceVerifierTest extends PHPUnit_Framework_TestCase
     public function test_counting_invalid_entity_throws_exception()
     {
         $this->registry->shouldReceive('getManagerForClass')
-            ->with(CountableEntityMock::class)
+            ->with(\LaravelDoctrine\Tests\Mocks\CountableEntityMock::class)
             ->andReturn(null);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('No Entity Manager could be found for [CountableEntityMock].');
+        $this->expectExceptionMessage('No Entity Manager could be found for [' . \LaravelDoctrine\Tests\Mocks\CountableEntityMock::class .'].');
 
-        $this->verifier->getCount(CountableEntityMock::class, 'email', 'test@email.com');
+        $this->verifier->getCount(\LaravelDoctrine\Tests\Mocks\CountableEntityMock::class, 'email', 'test@email.com');
     }
 
     protected function defaultGetCountMocks()
     {
         $this->registry->shouldReceive('getManagerForClass')
-                       ->with(CountableEntityMock::class)
+                       ->with(\LaravelDoctrine\Tests\Mocks\CountableEntityMock::class)
                        ->andReturn($this->em);
 
         $this->em->shouldReceive('createQueryBuilder')
@@ -200,7 +203,7 @@ class DoctrinePresenceVerifierTest extends PHPUnit_Framework_TestCase
                       ->andReturn($this->builder);
 
         $this->builder->shouldReceive('from')
-                      ->with(CountableEntityMock::class, 'e')
+                      ->with(\LaravelDoctrine\Tests\Mocks\CountableEntityMock::class, 'e')
                       ->once();
 
         $this->builder->shouldReceive('where')
@@ -218,7 +221,7 @@ class DoctrinePresenceVerifierTest extends PHPUnit_Framework_TestCase
     protected function defaultGetMultiCountMocks()
     {
         $this->registry->shouldReceive('getManagerForClass')
-                       ->with(CountableEntityMock::class)
+                       ->with(\LaravelDoctrine\Tests\Mocks\CountableEntityMock::class)
                        ->andReturn($this->em);
 
         $this->em->shouldReceive('createQueryBuilder')
@@ -229,14 +232,14 @@ class DoctrinePresenceVerifierTest extends PHPUnit_Framework_TestCase
                       ->andReturn($this->builder);
 
         $this->builder->shouldReceive('from')
-                      ->with(CountableEntityMock::class, 'e')
+                      ->with(\LaravelDoctrine\Tests\Mocks\CountableEntityMock::class, 'e')
                       ->once();
 
         $this->builder->shouldReceive('where')
                       ->once();
 
         $this->builder->shouldReceive('expr')->andReturn($this->builder);
-        $this->builder->shouldReceive('in')->with("e.email", ['test@email.com']);
+        $this->builder->shouldReceive('in')->with('e.email', ['test@email.com']);
 
         $this->builder->shouldReceive('getQuery')
                       ->once()->andReturn($this->query);
@@ -248,8 +251,4 @@ class DoctrinePresenceVerifierTest extends PHPUnit_Framework_TestCase
     {
         m::close();
     }
-}
-
-class CountableEntityMock
-{
 }

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -1,0 +1,10 @@
+<?php
+
+if (! function_exists('storage_path')) {
+    function storage_path($path = null)
+    {
+        $storage = __DIR__ . DIRECTORY_SEPARATOR . '../../Stubs/storage';
+
+        return $path === null ? $storage : $storage . DIRECTORY_SEPARATOR . $path;
+    }
+}


### PR DESCRIPTION
### Changes proposed in this pull request:
- updated all the dependencies
- tests (since phpunit 5 differs so much from 7)
- use `laravel/framework` instead of `illuminate/*` since in the code you call `database_path`/`base_path`/etc. and that makes those functions undefined during development

Also, it should target 1.5 I think