### PR TITLE
[Feature] Allow configuration of Faker locale through config

### DIFF
--- a/src/DoctrineServiceProvider.php
+++ b/src/DoctrineServiceProvider.php
@@ -308,8 +308,8 @@ class DoctrineServiceProvider extends ServiceProvider
      */
     protected function registerEntityFactory()
     {
-        $this->app->singleton(FakerGenerator::class, function () {
-            return FakerFactory::create();
+        $this->app->singleton(FakerGenerator::class, function ($app) {
+            return FakerFactory::create($app['config']->get('app.faker_locale', 'en_US'));
         });
 
         $this->app->singleton(EntityFactory::class, function ($app) {


### PR DESCRIPTION

This is in line with https://github.com/laravel/framework/pull/17895
Since [5.4] Laravel has been able to take the Faker locale form `config(app.faker_locale)`
In [5.7] https://github.com/laravel/laravel/pull/4785 added the option to the `app/config.php`
