### PR TITLE
 [FIX] laravel 5.8 update. composer and helpers fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,25 +18,25 @@
     "require": {
         "php": ">=7.0",
         "doctrine/orm": "2.5.*|2.6.*",
-        "illuminate/auth": "5.5.*|5.6.*|5.7.*",
-        "illuminate/console": "5.5.*|5.6.*|5.7.*",
-        "illuminate/container": "5.5.*|5.6.*|5.7.*",
-        "illuminate/contracts": "5.5.*|5.6.*|5.7.*",
-        "illuminate/pagination": "5.5.*|5.6.*|5.7.*",
-        "illuminate/routing": "5.5.*|5.6.*|5.7.*",
-        "illuminate/support": "5.5.*|5.6.*|5.7.*",
-        "illuminate/validation": "5.5.*|5.6.*|5.7.*",
-        "illuminate/view": "5.5.*|5.6.*|5.7.*",
+        "illuminate/auth": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "illuminate/console": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "illuminate/container": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "illuminate/pagination": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "illuminate/routing": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "illuminate/validation": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "illuminate/view": "5.5.*|5.6.*|5.7.*|5.8.*",
         "symfony/serializer": "^2.7|~3.0|~4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0",
         "mockery/mockery": "^1.0",
-        "barryvdh/laravel-debugbar": "~2.0",
+        "barryvdh/laravel-debugbar": "~2.0|~3.0",
         "itsgoingd/clockwork": "~1.9",
-        "illuminate/log": "5.5.*|5.6.*|5.7.*",
-        "illuminate/notifications": "5.5.*|5.6.*|5.7.*",
-        "illuminate/queue": "5.5.*|5.6.*|5.7.*"
+        "illuminate/log": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "illuminate/notifications": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "illuminate/queue": "5.5.*|5.6.*|5.7.*|5.8.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Auth/DoctrineUserProvider.php
+++ b/src/Auth/DoctrineUserProvider.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\EntityRepository;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Hashing\Hasher;
+use Illuminate\Support\Str;
 use ReflectionClass;
 
 class DoctrineUserProvider implements UserProvider
@@ -92,7 +93,7 @@ class DoctrineUserProvider implements UserProvider
     {
         $criteria = [];
         foreach ($credentials as $key => $value) {
-            if (!str_contains($key, 'password')) {
+            if (!Str::contains($key, 'password')) {
                 $criteria[$key] = $value;
             }
         }

--- a/src/Configuration/Cache/IlluminateCacheAdapter.php
+++ b/src/Configuration/Cache/IlluminateCacheAdapter.php
@@ -53,24 +53,15 @@ class IlluminateCacheAdapter extends CacheProvider
      * @param int    $lifeTime The lifetime. If != 0, sets a specific lifetime for this
      *                         cache entry (0 => infinite lifeTime).
      *
-     * @return bool TRUE always, because the cache repository have void return
+     * @return bool
      */
     protected function doSave($id, $data, $lifeTime = false)
     {
         if (!$lifeTime) {
-            $this->cache->forever($id, $data);
-
-            return true;
+            reutrn $this->cache->forever($id, $data);
         }
 
-        // Laravel cache system accept expire times in minutes
-        // while Doctrine accept it in seconds, so we need to convert $lifeTime from seconds to minutes
-        // before passing it to Laravel cache repository
-        $lifeTimeMinutes = $lifeTime / 60;
-
-        $this->cache->put($id, $data, $lifeTimeMinutes);
-
-        return true;
+        return $this->cache->put($id, $data, $lifeTime);
     }
 
     /**

--- a/src/Configuration/Cache/IlluminateCacheAdapter.php
+++ b/src/Configuration/Cache/IlluminateCacheAdapter.php
@@ -58,7 +58,7 @@ class IlluminateCacheAdapter extends CacheProvider
     protected function doSave($id, $data, $lifeTime = false)
     {
         if (!$lifeTime) {
-            reutrn $this->cache->forever($id, $data);
+            return $this->cache->forever($id, $data);
         }
 
         return $this->cache->put($id, $data, $lifeTime);

--- a/src/Configuration/Cache/IlluminateCacheAdapter.php
+++ b/src/Configuration/Cache/IlluminateCacheAdapter.php
@@ -58,10 +58,12 @@ class IlluminateCacheAdapter extends CacheProvider
     protected function doSave($id, $data, $lifeTime = false)
     {
         if (!$lifeTime) {
-            return $this->cache->forever($id, $data);
+            $this->cache->forever($id, $data);
+        } else {
+            $this->cache->put($id, $data, $lifeTime);
         }
 
-        return $this->cache->put($id, $data, $lifeTime);
+        return true;
     }
 
     /**

--- a/src/Configuration/Connections/MysqlConnection.php
+++ b/src/Configuration/Connections/MysqlConnection.php
@@ -2,6 +2,8 @@
 
 namespace LaravelDoctrine\ORM\Configuration\Connections;
 
+use Illuminate\Support\Arr;
+
 class MysqlConnection extends Connection
 {
     /**
@@ -13,17 +15,17 @@ class MysqlConnection extends Connection
     {
         return [
             'driver'                => 'pdo_mysql',
-            'host'                  => array_get($settings, 'host'),
-            'dbname'                => array_get($settings, 'database'),
-            'user'                  => array_get($settings, 'username'),
-            'password'              => array_get($settings, 'password'),
-            'charset'               => array_get($settings, 'charset'),
-            'port'                  => array_get($settings, 'port'),
-            'unix_socket'           => array_get($settings, 'unix_socket'),
-            'prefix'                => array_get($settings, 'prefix'),
-            'defaultTableOptions'   => array_get($settings, 'defaultTableOptions', []),
-            'driverOptions'         => array_get($settings, 'driverOptions', []),
-            'serverVersion'         => array_get($settings, 'serverVersion'),
+            'host'                  => Arr::get($settings, 'host'),
+            'dbname'                => Arr::get($settings, 'database'),
+            'user'                  => Arr::get($settings, 'username'),
+            'password'              => Arr::get($settings, 'password'),
+            'charset'               => Arr::get($settings, 'charset'),
+            'port'                  => Arr::get($settings, 'port'),
+            'unix_socket'           => Arr::get($settings, 'unix_socket'),
+            'prefix'                => Arr::get($settings, 'prefix'),
+            'defaultTableOptions'   => Arr::get($settings, 'defaultTableOptions', []),
+            'driverOptions'         => Arr::get($settings, 'driverOptions', []),
+            'serverVersion'         => Arr::get($settings, 'serverVersion'),
         ];
     }
 }

--- a/src/Configuration/Connections/OracleConnection.php
+++ b/src/Configuration/Connections/OracleConnection.php
@@ -2,6 +2,8 @@
 
 namespace LaravelDoctrine\ORM\Configuration\Connections;
 
+use Illuminate\Support\Arr;
+
 class OracleConnection extends Connection
 {
     /**
@@ -13,17 +15,17 @@ class OracleConnection extends Connection
     {
         return [
             'driver'                => 'oci8',
-            'host'                  => array_get($settings, 'host'),
-            'dbname'                => array_get($settings, 'database'),
-            'servicename'           => array_get($settings, 'service_name'),
-            'service'               => array_get($settings, 'service'),
-            'user'                  => array_get($settings, 'username'),
-            'password'              => array_get($settings, 'password'),
-            'charset'               => array_get($settings, 'charset'),
-            'port'                  => array_get($settings, 'port'),
-            'prefix'                => array_get($settings, 'prefix'),
-            'defaultTableOptions'   => array_get($settings, 'defaultTableOptions', []),
-            'persistent'            => array_get($settings, 'persistent'),
+            'host'                  => Arr::get($settings, 'host'),
+            'dbname'                => Arr::get($settings, 'database'),
+            'servicename'           => Arr::get($settings, 'service_name'),
+            'service'               => Arr::get($settings, 'service'),
+            'user'                  => Arr::get($settings, 'username'),
+            'password'              => Arr::get($settings, 'password'),
+            'charset'               => Arr::get($settings, 'charset'),
+            'port'                  => Arr::get($settings, 'port'),
+            'prefix'                => Arr::get($settings, 'prefix'),
+            'defaultTableOptions'   => Arr::get($settings, 'defaultTableOptions', []),
+            'persistent'            => Arr::get($settings, 'persistent'),
         ];
     }
 }

--- a/src/Configuration/Connections/PgsqlConnection.php
+++ b/src/Configuration/Connections/PgsqlConnection.php
@@ -2,6 +2,8 @@
 
 namespace LaravelDoctrine\ORM\Configuration\Connections;
 
+use Illuminate\Support\Arr;
+
 class PgsqlConnection extends Connection
 {
     /**
@@ -13,16 +15,16 @@ class PgsqlConnection extends Connection
     {
         return [
             'driver'              => 'pdo_pgsql',
-            'host'                => array_get($settings, 'host'),
-            'dbname'              => array_get($settings, 'database'),
-            'user'                => array_get($settings, 'username'),
-            'password'            => array_get($settings, 'password'),
-            'charset'             => array_get($settings, 'charset'),
-            'port'                => array_get($settings, 'port'),
-            'sslmode'             => array_get($settings, 'sslmode'),
-            'prefix'              => array_get($settings, 'prefix'),
-            'defaultTableOptions' => array_get($settings, 'defaultTableOptions', []),
-            'serverVersion'       => array_get($settings, 'serverVersion'),
+            'host'                => Arr::get($settings, 'host'),
+            'dbname'              => Arr::get($settings, 'database'),
+            'user'                => Arr::get($settings, 'username'),
+            'password'            => Arr::get($settings, 'password'),
+            'charset'             => Arr::get($settings, 'charset'),
+            'port'                => Arr::get($settings, 'port'),
+            'sslmode'             => Arr::get($settings, 'sslmode'),
+            'prefix'              => Arr::get($settings, 'prefix'),
+            'defaultTableOptions' => Arr::get($settings, 'defaultTableOptions', []),
+            'serverVersion'       => Arr::get($settings, 'serverVersion'),
         ];
     }
 }

--- a/src/Configuration/Connections/SqliteConnection.php
+++ b/src/Configuration/Connections/SqliteConnection.php
@@ -3,6 +3,7 @@
 namespace LaravelDoctrine\ORM\Configuration\Connections;
 
 use Illuminate\Support\Str;
+use Illuminate\Support\Arr;
 
 class SqliteConnection extends Connection
 {
@@ -15,12 +16,12 @@ class SqliteConnection extends Connection
     {
         return [
             'driver'              => 'pdo_sqlite',
-            'user'                => array_get($settings, 'username'),
-            'password'            => array_get($settings, 'password'),
-            'prefix'              => array_get($settings, 'prefix'),
+            'user'                => Arr::get($settings, 'username'),
+            'password'            => Arr::get($settings, 'password'),
+            'prefix'              => Arr::get($settings, 'prefix'),
             'memory'              => $this->isMemory($settings),
-            'path'                => array_get($settings, 'database'),
-            'defaultTableOptions' => array_get($settings, 'defaultTableOptions', []),
+            'path'                => Arr::get($settings, 'database'),
+            'defaultTableOptions' => Arr::get($settings, 'defaultTableOptions', []),
         ];
     }
 
@@ -31,6 +32,6 @@ class SqliteConnection extends Connection
      */
     protected function isMemory(array $settings = [])
     {
-        return Str::startsWith(array_get($settings, 'database'), ':memory');
+        return Str::startsWith(Arr::get($settings, 'database'), ':memory');
     }
 }

--- a/src/Configuration/Connections/SqliteConnection.php
+++ b/src/Configuration/Connections/SqliteConnection.php
@@ -2,8 +2,8 @@
 
 namespace LaravelDoctrine\ORM\Configuration\Connections;
 
-use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 class SqliteConnection extends Connection
 {

--- a/src/Configuration/Connections/SqlsrvConnection.php
+++ b/src/Configuration/Connections/SqlsrvConnection.php
@@ -2,6 +2,8 @@
 
 namespace LaravelDoctrine\ORM\Configuration\Connections;
 
+use Illuminate\Support\Arr;
+
 class SqlsrvConnection extends Connection
 {
     /**
@@ -13,15 +15,15 @@ class SqlsrvConnection extends Connection
     {
         return [
             'driver'              => 'pdo_sqlsrv',
-            'host'                => array_get($settings, 'host'),
-            'dbname'              => array_get($settings, 'database'),
-            'user'                => array_get($settings, 'username'),
-            'password'            => array_get($settings, 'password'),
-            'port'                => array_get($settings, 'port'),
-            'prefix'              => array_get($settings, 'prefix'),
-            'charset'             => array_get($settings, 'charset'),
-            'defaultTableOptions' => array_get($settings, 'defaultTableOptions', []),
-            'serverVersion'       => array_get($settings, 'serverVersion'),
+            'host'                => Arr::get($settings, 'host'),
+            'dbname'              => Arr::get($settings, 'database'),
+            'user'                => Arr::get($settings, 'username'),
+            'password'            => Arr::get($settings, 'password'),
+            'port'                => Arr::get($settings, 'port'),
+            'prefix'              => Arr::get($settings, 'prefix'),
+            'charset'             => Arr::get($settings, 'charset'),
+            'defaultTableOptions' => Arr::get($settings, 'defaultTableOptions', []),
+            'serverVersion'       => Arr::get($settings, 'serverVersion'),
         ];
     }
 }

--- a/src/Configuration/MetaData/Annotations.php
+++ b/src/Configuration/MetaData/Annotations.php
@@ -3,6 +3,7 @@
 namespace LaravelDoctrine\ORM\Configuration\MetaData;
 
 use Doctrine\ORM\Configuration;
+use Illuminate\Support\Arr;
 
 class Annotations extends MetaData
 {
@@ -14,8 +15,8 @@ class Annotations extends MetaData
     public function resolve(array $settings = [])
     {
         return (new Configuration())->newDefaultAnnotationDriver(
-            array_get($settings, 'paths', []),
-            array_get($settings, 'simple', false)
+            Arr::get($settings, 'paths', []),
+            Arr::get($settings, 'simple', false)
         );
     }
 }

--- a/src/Configuration/MetaData/Config.php
+++ b/src/Configuration/MetaData/Config.php
@@ -3,6 +3,7 @@
 namespace LaravelDoctrine\ORM\Configuration\MetaData;
 
 use Illuminate\Contracts\Config\Repository;
+use Illuminate\Support\Arr;
 use LaravelDoctrine\ORM\Configuration\MetaData\Config\ConfigDriver;
 
 class Config extends MetaData
@@ -28,7 +29,7 @@ class Config extends MetaData
     public function resolve(array $settings = [])
     {
         return new ConfigDriver(
-            $this->config->get(array_get($settings, 'mapping_file'), [])
+            $this->config->get(Arr::get($settings, 'mapping_file'), [])
         );
     }
 }

--- a/src/Configuration/MetaData/Config/ConfigDriver.php
+++ b/src/Configuration/MetaData/Config/ConfigDriver.php
@@ -4,6 +4,7 @@ namespace LaravelDoctrine\ORM\Configuration\MetaData\Config;
 
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Illuminate\Support\Arr;
 
 class ConfigDriver extends YamlDriver implements MappingDriver
 {
@@ -53,6 +54,6 @@ class ConfigDriver extends YamlDriver implements MappingDriver
      */
     public function getElement($className)
     {
-        return array_get($this->mappings, $className);
+        return Arr::get($this->mappings, $className);
     }
 }

--- a/src/Configuration/MetaData/Fluent.php
+++ b/src/Configuration/MetaData/Fluent.php
@@ -5,10 +5,10 @@ namespace LaravelDoctrine\ORM\Configuration\MetaData;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Arr;
 use LaravelDoctrine\Fluent\Builders\Builder;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadataFactory;
 use LaravelDoctrine\Fluent\FluentDriver;
-use Illuminate\Support\Arr;
 use LaravelDoctrine\ORM\Configuration\LaravelNamingStrategy;
 
 class Fluent extends MetaData

--- a/src/Configuration/MetaData/Fluent.php
+++ b/src/Configuration/MetaData/Fluent.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Container\Container;
 use LaravelDoctrine\Fluent\Builders\Builder;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadataFactory;
 use LaravelDoctrine\Fluent\FluentDriver;
+use Illuminate\Support\Arr;
 use LaravelDoctrine\ORM\Configuration\LaravelNamingStrategy;
 
 class Fluent extends MetaData
@@ -32,7 +33,7 @@ class Fluent extends MetaData
      */
     public function resolve(array $settings = [])
     {
-        $driver         = new FluentDriver(array_get($settings, 'mappings', []));
+        $driver         = new FluentDriver(Arr::get($settings, 'mappings', []));
 
         $namingStrategy = $this->getNamingStrategy($settings);
 
@@ -49,7 +50,7 @@ class Fluent extends MetaData
      */
     protected function getNamingStrategy(array $settings = [])
     {
-        return $this->container->make(array_get($settings, 'naming_strategy', LaravelNamingStrategy::class));
+        return $this->container->make(Arr::get($settings, 'naming_strategy', LaravelNamingStrategy::class));
     }
 
     /**

--- a/src/Configuration/MetaData/Php.php
+++ b/src/Configuration/MetaData/Php.php
@@ -3,6 +3,7 @@
 namespace LaravelDoctrine\ORM\Configuration\MetaData;
 
 use Doctrine\Common\Persistence\Mapping\Driver\PHPDriver;
+use Illuminate\Support\Arr;
 
 class Php extends MetaData
 {
@@ -14,7 +15,7 @@ class Php extends MetaData
     public function resolve(array $settings = [])
     {
         return new PHPDriver(
-            array_get($settings, 'paths')
+            Arr::get($settings, 'paths')
         );
     }
 }

--- a/src/Configuration/MetaData/SimplifiedXml.php
+++ b/src/Configuration/MetaData/SimplifiedXml.php
@@ -3,6 +3,7 @@
 namespace LaravelDoctrine\ORM\Configuration\MetaData;
 
 use Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver;
+use Illuminate\Support\Arr;
 
 class SimplifiedXml extends MetaData
 {
@@ -14,8 +15,8 @@ class SimplifiedXml extends MetaData
     public function resolve(array $settings = [])
     {
         return new SimplifiedXmlDriver(
-            array_get($settings, 'paths'),
-            array_get($settings, 'extension', SimplifiedXmlDriver::DEFAULT_FILE_EXTENSION)
+            Arr::get($settings, 'paths'),
+            Arr::get($settings, 'extension', SimplifiedXmlDriver::DEFAULT_FILE_EXTENSION)
         );
     }
 }

--- a/src/Configuration/MetaData/SimplifiedYaml.php
+++ b/src/Configuration/MetaData/SimplifiedYaml.php
@@ -3,6 +3,7 @@
 namespace LaravelDoctrine\ORM\Configuration\MetaData;
 
 use Doctrine\ORM\Mapping\Driver\SimplifiedYamlDriver;
+use Illuminate\Support\Arr;
 
 class SimplifiedYaml extends MetaData
 {
@@ -14,8 +15,8 @@ class SimplifiedYaml extends MetaData
     public function resolve(array $settings = [])
     {
         return new SimplifiedYamlDriver(
-            array_get($settings, 'paths'),
-            array_get($settings, 'extension', SimplifiedYamlDriver::DEFAULT_FILE_EXTENSION)
+            Arr::get($settings, 'paths'),
+            Arr::get($settings, 'extension', SimplifiedYamlDriver::DEFAULT_FILE_EXTENSION)
         );
     }
 }

--- a/src/Configuration/MetaData/StaticPhp.php
+++ b/src/Configuration/MetaData/StaticPhp.php
@@ -3,6 +3,7 @@
 namespace LaravelDoctrine\ORM\Configuration\MetaData;
 
 use Doctrine\Common\Persistence\Mapping\Driver\StaticPHPDriver;
+use Illuminate\Support\Arr;
 
 class StaticPhp extends MetaData
 {
@@ -14,7 +15,7 @@ class StaticPhp extends MetaData
     public function resolve(array $settings = [])
     {
         return new StaticPHPDriver(
-            array_get($settings, 'paths')
+            Arr::get($settings, 'paths')
         );
     }
 }

--- a/src/Configuration/MetaData/Xml.php
+++ b/src/Configuration/MetaData/Xml.php
@@ -3,6 +3,7 @@
 namespace LaravelDoctrine\ORM\Configuration\MetaData;
 
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Illuminate\Support\Arr;
 
 class Xml extends MetaData
 {
@@ -14,8 +15,8 @@ class Xml extends MetaData
     public function resolve(array $settings = [])
     {
         return new XmlDriver(
-            array_get($settings, 'paths'),
-            array_get($settings, 'extension', XmlDriver::DEFAULT_FILE_EXTENSION)
+            Arr::get($settings, 'paths'),
+            Arr::get($settings, 'extension', XmlDriver::DEFAULT_FILE_EXTENSION)
         );
     }
 }

--- a/src/Configuration/MetaData/Yaml.php
+++ b/src/Configuration/MetaData/Yaml.php
@@ -3,6 +3,7 @@
 namespace LaravelDoctrine\ORM\Configuration\MetaData;
 
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
+use Illuminate\Support\Arr;
 
 class Yaml extends MetaData
 {
@@ -14,8 +15,8 @@ class Yaml extends MetaData
     public function resolve(array $settings = [])
     {
         return new YamlDriver(
-            array_get($settings, 'paths'),
-            array_get($settings, 'extension', YamlDriver::DEFAULT_FILE_EXTENSION)
+            Arr::get($settings, 'paths'),
+            Arr::get($settings, 'extension', YamlDriver::DEFAULT_FILE_EXTENSION)
         );
     }
 }

--- a/src/Console/MappingImportCommand.php
+++ b/src/Console/MappingImportCommand.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Tools\Console\MetadataFilter;
 use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
 use Doctrine\ORM\Tools\EntityGenerator;
 use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
+use Illuminate\Support\Str;
 
 class MappingImportCommand extends Command
 {
@@ -45,12 +46,12 @@ class MappingImportCommand extends Command
         $simplified = false;
         $type       = $this->argument('mapping-type');
 
-        if (starts_with($type, 'simplified')) {
+        if (Str::startsWith($type, 'simplified')) {
             $simplified = true;
 
-            if (str_contains($type, 'xml')) {
+            if (Str::contains($type, 'xml')) {
                 $type       = 'xml';
-            } elseif (str_contains($type, 'yaml')) {
+            } elseif (Str::contains($type, 'yaml')) {
                 $type       = 'yaml';
             }
         }

--- a/src/DoctrineServiceProvider.php
+++ b/src/DoctrineServiceProvider.php
@@ -12,6 +12,7 @@ use Faker\Generator as FakerGenerator;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Notifications\ChannelManager;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use LaravelDoctrine\ORM\Auth\DoctrineUserProvider;
 use LaravelDoctrine\ORM\Configuration\Cache\CacheManager;
@@ -377,7 +378,7 @@ class DoctrineServiceProvider extends ServiceProvider
      */
     protected function isLumen()
     {
-        return str_contains($this->app->version(), 'Lumen');
+        return Str::contains($this->app->version(), 'Lumen');
     }
 
     /**

--- a/src/DoctrineServiceProvider.php
+++ b/src/DoctrineServiceProvider.php
@@ -278,13 +278,13 @@ class DoctrineServiceProvider extends ServiceProvider
         $manager = $this->app->make(ExtensionManager::class);
 
         if ($manager->needsBooting()) {
-            $this->app['events']->fire('doctrine.extensions.booting');
+            $this->app['events']->dispatch('doctrine.extensions.booting');
 
             $this->app->make(ExtensionManager::class)->boot(
                 $this->app['registry']
             );
 
-            $this->app['events']->fire('doctrine.extensions.booted');
+            $this->app['events']->dispatch('doctrine.extensions.booted');
         }
     }
 

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Tools\Setup;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use LaravelDoctrine\ORM\Configuration\Cache\CacheManager;
 use LaravelDoctrine\ORM\Configuration\Connections\ConnectionManager;
@@ -21,7 +22,6 @@ use LaravelDoctrine\ORM\Configuration\MetaData\MetaDataManager;
 use LaravelDoctrine\ORM\Extensions\MappingDriverChain;
 use LaravelDoctrine\ORM\Resolvers\EntityListenerResolver;
 use ReflectionException;
-use Illuminate\Support\Arr;
 
 class EntityManagerFactory
 {

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -21,6 +21,7 @@ use LaravelDoctrine\ORM\Configuration\MetaData\MetaDataManager;
 use LaravelDoctrine\ORM\Extensions\MappingDriverChain;
 use LaravelDoctrine\ORM\Resolvers\EntityListenerResolver;
 use ReflectionException;
+use Illuminate\Support\Arr;
 
 class EntityManagerFactory
 {
@@ -96,8 +97,8 @@ class EntityManagerFactory
         $defaultDriver = $this->config->get('doctrine.cache.default', 'array');
 
         $configuration = $this->setup->createConfiguration(
-            array_get($settings, 'dev', false),
-            array_get($settings, 'proxies.path'),
+            Arr::get($settings, 'dev', false),
+            Arr::get($settings, 'proxies.path'),
             $this->cache->driver($defaultDriver)
         );
 
@@ -125,7 +126,7 @@ class EntityManagerFactory
         $this->setRepositoryFactory($settings, $configuration);
 
         $configuration->setDefaultRepositoryClassName(
-            array_get($settings, 'repository', EntityRepository::class)
+            Arr::get($settings, 'repository', EntityRepository::class)
         );
 
         $configuration->setEntityListenerResolver($this->resolver);
@@ -153,7 +154,7 @@ class EntityManagerFactory
     private function setMetadataDriver(array $settings, Configuration $configuration)
     {
         $metadata = $this->meta->driver(
-            array_get($settings, 'meta'),
+            Arr::get($settings, 'meta'),
             $settings,
             false
         );
@@ -251,7 +252,7 @@ class EntityManagerFactory
     protected function registerPaths(array $settings = [], Configuration $configuration)
     {
         $configuration->getMetadataDriverImpl()->addPaths(
-            array_get($settings, 'paths', [])
+            Arr::get($settings, 'paths', [])
         );
     }
 
@@ -261,9 +262,9 @@ class EntityManagerFactory
      */
     protected function setRepositoryFactory($settings, Configuration $configuration)
     {
-        if (array_get($settings, 'repository_factory', false)) {
+        if (Arr::get($settings, 'repository_factory', false)) {
             $configuration->setRepositoryFactory(
-                $this->container->make(array_get($settings, 'repository_factory', false))
+                $this->container->make(Arr::get($settings, 'repository_factory', false))
             );
         }
     }
@@ -275,14 +276,14 @@ class EntityManagerFactory
     protected function configureProxies(array $settings = [], Configuration $configuration)
     {
         $configuration->setProxyDir(
-            array_get($settings, 'proxies.path')
+            Arr::get($settings, 'proxies.path')
         );
 
         $configuration->setAutoGenerateProxyClasses(
-            array_get($settings, 'proxies.auto_generate', false)
+            Arr::get($settings, 'proxies.auto_generate', false)
         );
 
-        if ($namespace = array_get($settings, 'proxies.namespace', false)) {
+        if ($namespace = Arr::get($settings, 'proxies.namespace', false)) {
             $configuration->setProxyNamespace($namespace);
         }
     }
@@ -306,7 +307,7 @@ class EntityManagerFactory
      */
     protected function setNamingStrategy(array $settings = [], Configuration $configuration)
     {
-        $strategy = array_get($settings, 'naming_strategy', LaravelNamingStrategy::class);
+        $strategy = Arr::get($settings, 'naming_strategy', LaravelNamingStrategy::class);
 
         $configuration->setNamingStrategy(
             $this->container->make($strategy)
@@ -395,7 +396,7 @@ class EntityManagerFactory
             'LaravelDoctrine'
         );
 
-        foreach (array_get($settings, 'namespaces', []) as $alias => $namespace) {
+        foreach (Arr::get($settings, 'namespaces', []) as $alias => $namespace) {
             // Add an alias for the namespace using the key
             if (is_string($alias)) {
                 $configuration->addEntityNamespace($alias, $namespace);
@@ -417,7 +418,7 @@ class EntityManagerFactory
      */
     protected function decorateManager(array $settings = [], EntityManagerInterface $manager)
     {
-        if ($decorator = array_get($settings, 'decorator', false)) {
+        if ($decorator = Arr::get($settings, 'decorator', false)) {
             if (!class_exists($decorator)) {
                 throw new InvalidArgumentException("EntityManagerDecorator {$decorator} does not exist");
             }
@@ -435,7 +436,7 @@ class EntityManagerFactory
      */
     protected function getConnectionDriver(array $settings = [])
     {
-        $connection = array_get($settings, 'connection');
+        $connection = Arr::get($settings, 'connection');
         $key        = 'database.connections.' . $connection;
 
         if (!$this->config->has($key)) {
@@ -453,7 +454,7 @@ class EntityManagerFactory
      */
     protected function registerMappingTypes(array $settings = [], EntityManagerInterface $manager)
     {
-        foreach (array_get($settings, 'mapping_types', []) as $dbType => $doctrineType) {
+        foreach (Arr::get($settings, 'mapping_types', []) as $dbType => $doctrineType) {
             // Throw DBALException if Doctrine Type is not found.
             $manager->getConnection()->getDatabasePlatform()->registerDoctrineTypeMapping($dbType, $doctrineType);
         }

--- a/src/Extensions/TablePrefix/TablePrefixExtension.php
+++ b/src/Extensions/TablePrefix/TablePrefixExtension.php
@@ -7,6 +7,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use LaravelDoctrine\ORM\Extensions\Extension;
+use Illuminate\Support\Arr;
 
 class TablePrefixExtension implements Extension
 {
@@ -41,6 +42,6 @@ class TablePrefixExtension implements Extension
     {
         $params = $connection->getParams();
 
-        return array_get($params, 'prefix');
+        return Arr::get($params, 'prefix');
     }
 }

--- a/src/Extensions/TablePrefix/TablePrefixExtension.php
+++ b/src/Extensions/TablePrefix/TablePrefixExtension.php
@@ -6,8 +6,8 @@ use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
-use LaravelDoctrine\ORM\Extensions\Extension;
 use Illuminate\Support\Arr;
+use LaravelDoctrine\ORM\Extensions\Extension;
 
 class TablePrefixExtension implements Extension
 {

--- a/tests/Configuration/Cache/IlluminateCacheAdapterTest.php
+++ b/tests/Configuration/Cache/IlluminateCacheAdapterTest.php
@@ -77,8 +77,8 @@ class IlluminateCacheAdapterTest extends PHPUnit_Framework_TestCase
                          ->once()->andReturn(1);
 
         $this->repository->shouldReceive('put')
-                         ->with('[1][1]', 'data', 1)
-                         ->once()->andReturn(null);
+                         ->with('[1][1]', 'data', 60)
+                         ->once()->andReturn(true);
 
         $this->assertTrue($this->cache->save(1, 'data', 60));
     }


### PR DESCRIPTION
### Changes proposed in this pull request:
- composer json change to support laravel 5.8
- replaced deprecated array and string helper functions (https://laravel-news.com/laravel-5-8-deprecates-string-and-array-helpers)