### PR TITLE
[FIX] Readme updated to reflect support for Laravel 5.6, 5.7 and 5.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Version | Supported Laravel Versions | Support
 1.1.x | 5.2.x |  EOL
 1.2.x | 5.2.x, 5.3.x | Security releases
 1.3.x | 5.4.x | Bugfix and security releases
-~1.4 | 5.5.x | New features
+~1.4.0 | 5.5.x | New features
 \>=1.4.3 | 5.6.x | New features
 \>=1.4.8 | 5.7.x | New features
 \>=1.4.10 | 5.8.x | New features

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ Version | Supported Laravel Versions | Support
 1.1.x | 5.2.x |  EOL
 1.2.x | 5.2.x, 5.3.x | Security releases
 1.3.x | 5.4.x | Bugfix and security releases
-\>= 1.4.0 | 5.5.x | New features
-\>= 1.4.3 | 5.5.x, 5.6.x | New features
-\>= 1.4.8 | 5.5.x, 5.6.x, 5.7.x | New features
-\>= 1.4.10 | 5.5.x, 5.6.x, 5.7.x, 5.8.x | New features
+\>=1.4.0 | 5.5.x | New features
+\>=1.4.3 | 5.5.x, 5.6.x | New features
+\>=1.4.8 | 5.5.x, 5.6.x, 5.7.x | New features
+\>=1.4.10 | 5.5.x, 5.6.x, 5.7.x, 5.8.x | New features
 
 
 Require this package  

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ Version | Supported Laravel Versions | Support
 1.1.x | 5.2.x |  EOL
 1.2.x | 5.2.x, 5.3.x | Security releases
 1.3.x | 5.4.x | Bugfix and security releases
-\>=1.4.0 | 5.5.x | New features
-\>=1.4.3 | 5.5.x, 5.6.x | New features
-\>=1.4.8 | 5.5.x, 5.6.x, 5.7.x | New features
-\>=1.4.10 | 5.5.x, 5.6.x, 5.7.x, 5.8.x | New features
+~1.4 | 5.5.x | New features
+\>=1.4.3 | 5.6.x | New features
+\>=1.4.8 | 5.7.x | New features
+\>=1.4.10 | 5.8.x | New features
 
 
 Require this package  

--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ Version | Supported Laravel Versions | Support
 1.1.x | 5.2.x |  EOL
 1.2.x | 5.2.x, 5.3.x | Security releases
 1.3.x | 5.4.x | Bugfix and security releases
-1.4.x | 5.5.x | New features
+\>= 1.4.0 | 5.5.x | New features
+\>= 1.4.3 | 5.5.x, 5.6.x | New features
+\>= 1.4.8 | 5.5.x, 5.6.x, 5.7.x | New features
+\>= 1.4.10 | 5.5.x, 5.6.x, 5.7.x, 5.8.x | New features
+
 
 Require this package  
 


### PR DESCRIPTION
### Changes proposed in this pull request:
- Update the table in README.md in composer syntax to reflect support among the 1.4.x releases for various versions of Laravel 5.5 and greater.