### PR TITLE
[FIX] Revert #289, Laravel 5.8 returns a boolean

### DIFF
--- a/src/Configuration/Cache/IlluminateCacheAdapter.php
+++ b/src/Configuration/Cache/IlluminateCacheAdapter.php
@@ -58,12 +58,10 @@ class IlluminateCacheAdapter extends CacheProvider
     protected function doSave($id, $data, $lifeTime = false)
     {
         if (!$lifeTime) {
-            $this->cache->forever($id, $data);
-        } else {
-            $this->cache->put($id, $data, $lifeTime);
+            return $this->cache->forever($id, $data);
         }
 
-        return true;
+        return $this->cache->put($id, $data, $lifeTime);
     }
 
     /**


### PR DESCRIPTION
Previously Laravel would return void, but this changed in Laravel 5.8. So we can now use the proper value returned from store.