### PR TITLE
[FIX] Revert changes to applying states in factory builder

### DIFF
--- a/src/Testing/FactoryBuilder.php
+++ b/src/Testing/FactoryBuilder.php
@@ -272,7 +272,7 @@ class FactoryBuilder
     protected function applyStates(array $definition, array $attributes = [])
     {
         foreach ($this->activeStates as $state) {
-            if (! isset($this->states[$this->class][$state])) {
+            if (! isset($this->states[$state])) {
                 if ($this->stateHasAfterCallback($state)) {
                     continue;
                 }
@@ -298,7 +298,7 @@ class FactoryBuilder
      */
     protected function stateAttributes($state, array $attributes)
     {
-        $stateAttributes = $this->states[$this->class][$state];
+        $stateAttributes = $this->states[$state];
 
         if (! is_callable($stateAttributes)) {
             return $stateAttributes;

--- a/tests/Testing/FactoryBuilderTest.php
+++ b/tests/Testing/FactoryBuilderTest.php
@@ -180,14 +180,12 @@ class FactoryBuilderTest extends MockeryTestCase
     public function test_it_handles_states()
     {
         $states = [
-            $this->aClass => [
-                'withState' => function () {
-                    return ['id' => 2, 'name' => 'stateful'];
-                },
-                'other' => function () {
-                    return ['id' => 3];
-                },
-            ]
+            'withState' => function () {
+                return ['id' => 2, 'name' => 'stateful'];
+            },
+            'other' => function () {
+                return ['id' => 3];
+            },
         ];
 
         $instance = $this->getFactoryBuilder([], $states)->states('withState')->make();


### PR DESCRIPTION
### Changes proposed in this pull request:
- The merge request that added the new factory callbacks (#363) unintentionally broke factory states.  This merge request reverts the changes to applying states.