### PR TITLE
[FIX] BootChain: If the registry has already been booted then just run the callback

### DIFF
--- a/src/BootChain.php
+++ b/src/BootChain.php
@@ -12,11 +12,24 @@ class BootChain
     protected static $resolveCallbacks = [];
 
     /**
+     * @var ManagerRegistry[]
+     */
+    protected static $registries = [];
+
+    /**
      * @param callable $callback
      */
     public static function add(callable  $callback)
     {
-        static::$resolveCallbacks[] = $callback;
+        if (empty(static::$registries)) {
+            static::$resolveCallbacks[] = $callback;
+        } else {
+            foreach (static::$registries as $registry) {
+                if (is_callable($callback)) {
+                    call_user_func($callback, $registry);
+                }
+            }
+        }
     }
 
     /**
@@ -24,6 +37,7 @@ class BootChain
      */
     public static function boot(ManagerRegistry $registry)
     {
+        static::$registries[] = $registry;
         foreach (static::$resolveCallbacks as $callback) {
             if (is_callable($callback)) {
                 call_user_func($callback, $registry);


### PR DESCRIPTION
Our Laravel application has got so big that something in the boot sequence is no longer happening in the expected order

The result of this is that `DoctrineServiceProvider` is being resolved before `AclServiceProvider` is booted and so our permissions are never setup

I have no idea if my fix in in the correct place but her it is.
BootChain keeps track of already resolved registries and if they are resolved it just runs the callback rather than storing it for later

### Changes proposed in this pull request:
- Immediately run onResolve callbacks if the ManagerRegistry has already been resolved