### PR TITLE
[FEATURE] Define custom DBAL\Connection to use.

### DIFF
--- a/src/Configuration/Connections/MysqlConnection.php
+++ b/src/Configuration/Connections/MysqlConnection.php
@@ -26,6 +26,7 @@ class MysqlConnection extends Connection
             'defaultTableOptions'   => Arr::get($settings, 'defaultTableOptions', []),
             'driverOptions'         => Arr::get($settings, 'driverOptions', []),
             'serverVersion'         => Arr::get($settings, 'serverVersion'),
+            'wrapperClass'          => Arr::get($settings, 'wrapperClass')
         ];
     }
 }

--- a/src/Configuration/Connections/OracleConnection.php
+++ b/src/Configuration/Connections/OracleConnection.php
@@ -26,6 +26,7 @@ class OracleConnection extends Connection
             'prefix'                => Arr::get($settings, 'prefix'),
             'defaultTableOptions'   => Arr::get($settings, 'defaultTableOptions', []),
             'persistent'            => Arr::get($settings, 'persistent'),
+            'wrapperClass'          => Arr::get($settings, 'wrapperClass')
         ];
     }
 }

--- a/src/Configuration/Connections/PgsqlConnection.php
+++ b/src/Configuration/Connections/PgsqlConnection.php
@@ -25,6 +25,7 @@ class PgsqlConnection extends Connection
             'prefix'              => Arr::get($settings, 'prefix'),
             'defaultTableOptions' => Arr::get($settings, 'defaultTableOptions', []),
             'serverVersion'       => Arr::get($settings, 'serverVersion'),
+            'wrapperClass'        => Arr::get($settings, 'wrapperClass')
         ];
     }
 }

--- a/src/Configuration/Connections/SqliteConnection.php
+++ b/src/Configuration/Connections/SqliteConnection.php
@@ -22,6 +22,7 @@ class SqliteConnection extends Connection
             'memory'              => $this->isMemory($settings),
             'path'                => Arr::get($settings, 'database'),
             'defaultTableOptions' => Arr::get($settings, 'defaultTableOptions', []),
+            'wrapperClass'        => Arr::get($settings, 'wrapperClass')
         ];
     }
 

--- a/src/Configuration/Connections/SqlsrvConnection.php
+++ b/src/Configuration/Connections/SqlsrvConnection.php
@@ -24,6 +24,7 @@ class SqlsrvConnection extends Connection
             'charset'             => Arr::get($settings, 'charset'),
             'defaultTableOptions' => Arr::get($settings, 'defaultTableOptions', []),
             'serverVersion'       => Arr::get($settings, 'serverVersion'),
+            'wrapperClass'        => Arr::get($settings, 'wrapperClass')
         ];
     }
 }

--- a/src/Testing/ConfigRepository.php
+++ b/src/Testing/ConfigRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace LaravelDoctrine\ORM\Testing;
+
+use Illuminate\Contracts\Config\Repository;
+
+class ConfigRepository implements Repository
+{
+    /**
+     * @var array
+     */
+    private $items;
+
+    public function __construct(array $items)
+    {
+        $this->items = $items;
+    }
+
+    public function all()
+    {
+        return $this->items;
+    }
+
+    public function get($key, $default = null)
+    {
+        return $this->items[$key] ?? $default;
+    }
+
+    public function set($key, $value = null)
+    {
+        // Pass
+    }
+
+    public function prepend($key, $value)
+    {
+        // Pass
+    }
+
+    public function has($key)
+    {
+        return array_key_exists($key, $this->items);
+    }
+
+    public function push($key, $value)
+    {
+        // Pass
+    }
+}

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -21,7 +21,9 @@ use LaravelDoctrine\ORM\Configuration\LaravelNamingStrategy;
 use LaravelDoctrine\ORM\Configuration\MetaData\MetaDataManager;
 use LaravelDoctrine\ORM\EntityManagerFactory;
 use LaravelDoctrine\ORM\Loggers\Logger;
+use LaravelDoctrine\ORM\Resolvers\EntityListenerResolver;
 use LaravelDoctrine\ORM\Resolvers\EntityListenerResolver as LaravelDoctrineEntityListenerResolver;
+use LaravelDoctrine\ORM\Testing\ConfigRepository;
 use Mockery as m;
 use Mockery\Mock;
 
@@ -482,6 +484,50 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
         $this->assertEntityManager($manager);
     }
 
+    public function test_wrapper_connection()
+    {
+        m::resetContainer();
+
+        $config = new ConfigRepository([
+            'database.connections.mysql' => [
+                'wrapperClass' => FakeConnection::class,
+                'driver'       => 'mysql'
+            ],
+            'doctrine' => [
+                'meta'       => 'annotations',
+                'connection' => 'mysql',
+                'paths'      => ['Entities'],
+                'proxies'    => [
+                    'path'          => 'dir',
+                    'auto_generate' => false,
+                    'namespace'     => 'namespace'
+                ],
+            ],
+            'doctrine.custom_datetime_functions' => [],
+            'doctrine.custom_numeric_functions'  => [],
+            'doctrine.custom_string_functions'   => []
+        ]);
+
+        $container = new \Illuminate\Container\Container();
+        $container->singleton(Repository::class, function () use ($config) {
+            return $config;
+        });
+
+        $factory = new EntityManagerFactory(
+            $container,
+            new Setup(),
+            new MetaDataManager($container),
+            new ConnectionManager($container),
+            new CacheManager($container),
+           $config,
+            new EntityListenerResolver($container)
+        );
+
+        $manager = $factory->create($config->get('doctrine'));
+
+        $this->assertInstanceOf(FakeConnection::class, $manager->getConnection());
+    }
+
     /**
      * MOCKS
      *
@@ -869,6 +915,10 @@ class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
             ],
         ];
     }
+}
+
+class FakeConnection extends Connection
+{
 }
 
 class FilterStub


### PR DESCRIPTION
### Changes proposed in this pull request:
Same configuration as master-slave. You can now optionally define
wrapperClass on `database.connections.<connection>.wrapperClass`.
