### PR TITLE
[FIX] Fix message wording in doctrine:schema:drop output

### DIFF
--- a/src/Console/SchemaDropCommand.php
+++ b/src/Console/SchemaDropCommand.php
@@ -71,7 +71,7 @@ class SchemaDropCommand extends Command
                 }
 
                 if (count($sql)) {
-                    $pluralization = (1 === count($sql)) ? 'query was' : 'queries were';
+                    $pluralization = (1 === count($sql)) ? 'query' : 'queries';
                     $this->message(sprintf('The Schema-Tool would execute <info>"%s"</info> %s to update the database.',
                         count($sql), $pluralization));
                     $this->message('Please run the operation by passing one - or both - of the following options:');


### PR DESCRIPTION
Just a quick fix for a wording error - an extraneous "was" or "were" being added.

```
alexuser@46419a0ca528:/var/www/html$ php artisan doctrine:schema:drop
...
The Schema-Tool would execute "3" queries were to update the database.
...
alexuser@46419a0ca528:/var/www/html$
```

Should be:

```
alexuser@46419a0ca528:/var/www/html$ php artisan doctrine:schema:drop
...
The Schema-Tool would execute "3" queries to update the database.
...
alexuser@46419a0ca528:/var/www/html$
```