### PR TITLE
[FIX] doctrine/persistence issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,9 @@
         "illuminate/notifications": "5.5.*|5.6.*|5.7.*|5.8.*",
         "illuminate/queue": "5.5.*|5.6.*|5.7.*|5.8.*"
     },
+    "conflict": {
+        "doctrine/persistence": ">=1.3@dev"
+    },
     "autoload": {
         "psr-4": {
             "LaravelDoctrine\\ORM\\": "src/"


### PR DESCRIPTION
`doctrine/persistence 1.3` introduced a change of namespace which breaks with `doctrine/orm 2.5`.


`doctrine/orm 2.5` does not use `doctrine/persistence`, so we are not able to require `doctrine/persistence 1.3` and fix issues related to change of namespace. Instead we must use the old doctrine/persistence until something else forces us to drop support of 7.0 in `laravel-doctrine/orm 1.4`.