### PR TITLE
Enable compatibility with doctrine/persistence 1.3+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,9 +38,6 @@
         "illuminate/notifications": "5.5.*|5.6.*|5.7.*|5.8.*",
         "illuminate/queue": "5.5.*|5.6.*|5.7.*|5.8.*"
     },
-    "conflict": {
-        "doctrine/persistence": ">=1.3@dev"
-    },
     "autoload": {
         "psr-4": {
             "LaravelDoctrine\\ORM\\": "src/"

--- a/src/DoctrineServiceProvider.php
+++ b/src/DoctrineServiceProvider.php
@@ -160,6 +160,9 @@ class DoctrineServiceProvider extends ServiceProvider
 
         $this->app->alias('registry', ManagerRegistry::class);
         $this->app->alias('registry', IlluminateRegistry::class);
+
+        // This alias is required for compatibility with doctrine/persistence 1.3+
+        $this->app->alias(ManagerRegistry::class, \Doctrine\Persistence\ManagerRegistry::class);
     }
 
     /**

--- a/tests/Middleware/SubstituteBindingsTest.php
+++ b/tests/Middleware/SubstituteBindingsTest.php
@@ -44,6 +44,8 @@ class SubstituteBindingsTest extends PHPUnit_Framework_TestCase
             return $router;
         });
 
+        $container->alias(ManagerRegistry::class, \Doctrine\Persistence\ManagerRegistry::class);
+
         $container->singleton(ManagerRegistry::class, function () {
             return $this->registry;
         });


### PR DESCRIPTION
### What & why?
A change in `doctrine/persistence` version 1.3 deprecated the `Doctrine\Common\Persistence\ManagerRegistry` class and introduced `Doctrine\Persistence\ManagerRegistry` class that is aliased by their
compatibility layer.

This however confuses Laravel's container, because it only picks service definitions whose identifiers directly match the requested type or were explicitly aliased in container.

Add an appropriate alias to the DoctrineServiceProvider so that container can identify both ManagerRegistries and inject one depending on the version of the doctrine/persistence supplied.

As a result a `conflict` section is removed from the `composer.json` file too.

### Testing
Running `./artisan doctrine:clear:metadata:cache` command

#### Before
 ```
$ ./artisan doctrine:clear:metadata:cache
 
   Illuminate\Contracts\Container\BindingResolutionException  : Target [Doctrine\Persistence\ManagerRegistry] is not instantiable.
 
  at .../vendor/laravel/framework/src/Illuminate/Container/Container.php:960
    956|         } else {
    957|             $message = "Target [$concrete] is not instantiable.";
    958|         }
    959|
  > 960|         throw new BindingResolutionException($message);
    961|     }
    962|
    963|     /**
    964|      * Throw an exception for an unresolvable primitive.
 
  Exception trace:
 
  1   Illuminate\Container\Container::notInstantiable("Doctrine\Persistence\ManagerRegistry")
      .../vendor/laravel/framework/src/Illuminate/Container/Container.php:794
 
  2   Illuminate\Container\Container::build("Doctrine\Persistence\ManagerRegistry")
      .../vendor/laravel/framework/src/Illuminate/Container/Container.php:667
 
  Please use the argument -v to see more details.
```

#### After
```
$ ./artisan doctrine:clear:metadata:cache
Clearing result cache entries for default entity manager
Successfully deleted cache entries.
```