### PR TITLE
[FIX] Support serverVersion for MasterSlaveConnection

### DIFF
--- a/src/Configuration/Connections/MasterSlaveConnection.php
+++ b/src/Configuration/Connections/MasterSlaveConnection.php
@@ -40,12 +40,18 @@ class MasterSlaveConnection extends Connection
     {
         $driver = $this->resolvedBaseSettings['driver'];
 
-        return [
+        $resolvedSettings = [
             'wrapperClass' => $settings['wrapperClass'] ?? MasterSlaveDoctrineWrapper::class,
             'driver'       => $driver,
             'master'       => $this->getConnectionData(isset($settings['write']) ? $settings['write'] : [], $driver),
             'slaves'       => $this->getSlavesConfig($settings['read'], $driver),
         ];
+
+        if (!empty($settings['serverVersion'])) {
+            $resolvedSettings['serverVersion'] = $settings['serverVersion'];
+        }
+
+        return $resolvedSettings;
     }
 
     /**

--- a/tests/Configuration/Connections/MasterSlaveConnectionTest.php
+++ b/tests/Configuration/Connections/MasterSlaveConnectionTest.php
@@ -88,6 +88,7 @@ class MasterSlaveConnectionTest extends PHPUnit_Framework_TestCase
                     'port' => 3309
                 ],
             ],
+            'serverVersion' => '5.8',
         ];
     }
 
@@ -99,9 +100,10 @@ class MasterSlaveConnectionTest extends PHPUnit_Framework_TestCase
     private function getExpectedConfig()
     {
         return [
-            'wrapperClass' => MasterSlaveDoctrineWrapper::class,
-            'driver'       => 'pdo_mysql',
-            'slaves'       => [
+            'wrapperClass'  => MasterSlaveDoctrineWrapper::class,
+            'driver'        => 'pdo_mysql',
+            'serverVersion' => '5.8',
+            'slaves'        => [
                 [
                     'host'        => 'localhost',
                     'user'        => 'homestead',
@@ -216,6 +218,7 @@ class MasterSlaveConnectionTest extends PHPUnit_Framework_TestCase
         $expectedConfigOracle                   = $this->getNodesExpectedConfig();
         $expectedConfigOracle['driver']         = 'oci8';
         $expectedConfigOracle['master']['user'] = 'homestead1';
+        $expectedConfigOracle['serverVersion']  = '5.8';
 
         return $expectedConfigOracle;
     }
@@ -233,6 +236,7 @@ class MasterSlaveConnectionTest extends PHPUnit_Framework_TestCase
         $expectedConfigPgsql['master']['sslmode']    = 'sslmode';
         $expectedConfigPgsql['slaves'][0]['sslmode'] = 'sslmode';
         $expectedConfigPgsql['slaves'][1]['sslmode'] = 'sslmode';
+        $expectedConfigPgsql['serverVersion']        = '5.8';
 
         return $expectedConfigPgsql;
     }
@@ -271,6 +275,7 @@ class MasterSlaveConnectionTest extends PHPUnit_Framework_TestCase
                 'memory'   => true,
                 'path'     => ':memory',
             ],
+            'serverVersion' => '5.8',
         ];
     }
 


### PR DESCRIPTION
### Changes proposed in this pull request:

Having multiple ORM connections in a MasterSlave configuration, creates loads of connections in order to detect the server version.

See https://github.com/laravel-doctrine/orm/issues/325