### PR TITLE
[FEATURE] Add `php_file` cache option

### DIFF
--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -157,7 +157,7 @@ return [
     | Configure meta-data, query and result caching here.
     | Optionally you can enable second level caching.
     |
-    | Available: apc|array|file|memcached|redis|void
+    | Available: apc|array|file|memcached|php_file|redis|void
     |
     */
     'cache' => [

--- a/src/Configuration/Cache/PhpFileCacheProvider.php
+++ b/src/Configuration/Cache/PhpFileCacheProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace LaravelDoctrine\ORM\Configuration\Cache;
+
+use Doctrine\Common\Cache\PhpFileCache;
+use Illuminate\Contracts\Config\Repository;
+use LaravelDoctrine\ORM\Configuration\Driver;
+use function storage_path;
+
+class PhpFileCacheProvider implements Driver
+{
+    /**
+     * @var Repository
+     */
+    protected $config;
+
+    /**
+     * @param Repository $config
+     */
+    public function __construct(Repository $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @param array $settings
+     *
+     * @return PhpFileCache
+     */
+    public function resolve(array $settings = [])
+    {
+        return new PhpFileCache(
+            $this->config->get('cache.stores.file.path', storage_path('framework/cache'))
+        );
+    }
+}

--- a/tests/Configuration/Cache/PhpFileCacheProviderTest.php
+++ b/tests/Configuration/Cache/PhpFileCacheProviderTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Doctrine\Common\Cache\PhpFileCache;
+use Illuminate\Contracts\Config\Repository;
+use LaravelDoctrine\ORM\Configuration\Cache\PhpFileCacheProvider;
+use Mockery as m;
+
+class PhpFileCacheProviderTest extends AbstractCacheProviderTest
+{
+    public function getProvider()
+    {
+        $config = m::mock(Repository::class);
+        $config->shouldReceive('get')
+            ->with('cache.stores.file.path', __DIR__ . DIRECTORY_SEPARATOR . '../../Stubs/storage/framework/cache')
+            ->once()
+            ->andReturn('/tmp');
+
+        return new PhpFileCacheProvider(
+            $config
+        );
+    }
+
+    public function getExpectedInstance()
+    {
+        return PhpFileCache::class;
+    }
+}


### PR DESCRIPTION
### Changes proposed in this pull request: 

Adds `php_file` as a cache type (opcache).