### PR TITLE
[FIX] Fixed callAfterCreating for one entity in FactoryBuilder::create

### DIFF
--- a/src/Testing/FactoryBuilder.php
+++ b/src/Testing/FactoryBuilder.php
@@ -115,7 +115,7 @@ class FactoryBuilder
 
         if ($this->amount === 1) {
             $manager->persist($results);
-            $this->callAfterCreating(collect($results));
+            $this->callAfterCreating(collect([$results]));
         } else {
             foreach ($results as $result) {
                 $manager->persist($result);


### PR DESCRIPTION
### Changes proposed in this pull request:

Fixed callAfterCreating for one entity in FactoryBuilder::create (laravel collect() method doesn't work correctly with one simple entity, but with array does)