### PR TITLE
[FEATURE] Add query parameters to PaginatorAdapter

### DIFF
--- a/src/Pagination/PaginatorAdapter.php
+++ b/src/Pagination/PaginatorAdapter.php
@@ -131,7 +131,7 @@ class PaginatorAdapter
     }
 
     /**
-     * @param  array  $params
+     * @param array $params
      *
      * @return $this
      */

--- a/src/Pagination/PaginatorAdapter.php
+++ b/src/Pagination/PaginatorAdapter.php
@@ -31,17 +31,24 @@ class PaginatorAdapter
     private $fetchJoinCollection;
 
     /**
+     * @var array
+     */
+    private $queryParams;
+
+    /**
      * @param AbstractQuery $query
      * @param int           $perPage
      * @param callable      $pageResolver
      * @param bool          $fetchJoinCollection
+     * @param array         $queryParams
      */
-    private function __construct(AbstractQuery $query, $perPage, $pageResolver, $fetchJoinCollection)
+    private function __construct(AbstractQuery $query, $perPage, $pageResolver, $fetchJoinCollection, $queryParams = [])
     {
         $this->query               = $query;
         $this->perPage             = $perPage;
         $this->pageResolver        = $pageResolver;
         $this->fetchJoinCollection = $fetchJoinCollection;
+        $this->queryParams         = $queryParams;
     }
 
     /**
@@ -49,10 +56,11 @@ class PaginatorAdapter
      * @param int           $perPage
      * @param string        $pageName
      * @param bool          $fetchJoinCollection
+     * @param array         $queryParams
      *
      * @return PaginatorAdapter
      */
-    public static function fromRequest(AbstractQuery $query, $perPage = 15, $pageName = 'page', $fetchJoinCollection = true)
+    public static function fromRequest(AbstractQuery $query, $perPage = 15, $pageName = 'page', $fetchJoinCollection = true, $queryParams = [])
     {
         return new static(
             $query,
@@ -60,7 +68,8 @@ class PaginatorAdapter
             function () use ($pageName) {
                 return Paginator::resolveCurrentPage($pageName);
             },
-            $fetchJoinCollection
+            $fetchJoinCollection,
+            $queryParams
         );
     }
 
@@ -69,10 +78,11 @@ class PaginatorAdapter
      * @param int           $perPage
      * @param int           $page
      * @param bool          $fetchJoinCollection
+     * @param array         $queryParams
      *
      * @return PaginatorAdapter
      */
-    public static function fromParams(AbstractQuery $query, $perPage = 15, $page = 1, $fetchJoinCollection = true)
+    public static function fromParams(AbstractQuery $query, $perPage = 15, $page = 1, $fetchJoinCollection = true, $queryParams = [])
     {
         return new static(
             $query,
@@ -80,7 +90,8 @@ class PaginatorAdapter
             function () use ($page) {
                 return $page;
             },
-            $fetchJoinCollection
+            $fetchJoinCollection,
+            $queryParams
         );
     }
 
@@ -117,6 +128,26 @@ class PaginatorAdapter
     public function getQuery()
     {
         return $this->query;
+    }
+
+    /**
+     * @param  array  $params
+     *
+     * @return $this
+     */
+    public function queryParams(array $params = [])
+    {
+        $this->queryParams = $params;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getQueryParams()
+    {
+        return $this->queryParams;
     }
 
     /**
@@ -176,13 +207,14 @@ class PaginatorAdapter
     {
         $results     = iterator_to_array($doctrinePaginator);
         $path        = Paginator::resolveCurrentPath();
+        $query       = $this->queryParams;
 
         return new LengthAwarePaginator(
             $results,
             $doctrinePaginator->count(),
             $perPage,
             $page,
-            compact('path')
+            compact('path', 'query')
         );
     }
 

--- a/tests/Pagination/PaginatorAdapterTest.php
+++ b/tests/Pagination/PaginatorAdapterTest.php
@@ -53,7 +53,7 @@ class PaginatorAdapterTest extends TestCase
 
         $paginator = $adapter->make();
 
-        $this->assertContains('foo=bar', $paginator->url(1));
+        $this->assertStringContainsString('foo=bar', $paginator->url(1));
     }
 
     public function testQueryParametersAreProducedInUrlFromRequest()
@@ -65,7 +65,7 @@ class PaginatorAdapterTest extends TestCase
 
         $paginator = $adapter->make();
 
-        $this->assertContains('foo=bar', $paginator->url(1));
+        $this->assertStringContainsString('foo=bar', $paginator->url(1));
     }
 
     /**

--- a/tests/Pagination/PaginatorAdapterTest.php
+++ b/tests/Pagination/PaginatorAdapterTest.php
@@ -44,6 +44,30 @@ class PaginatorAdapterTest extends TestCase
         $this->assertEquals(13, $paginator->currentPage());
     }
 
+    public function testQueryParametersAreProducedInUrlFromParams()
+    {
+        $em      = $this->mockEntityManager();
+        $query   = (new Query($em))->setDQL('SELECT f FROM Foo f');
+        $adapter = PaginatorAdapter::fromParams($query, 15, 2, false)
+            ->queryParams(['foo' => 'bar']);
+
+        $paginator = $adapter->make();
+
+        $this->assertContains('foo=bar', $paginator->url(1));
+    }
+
+    public function testQueryParametersAreProducedInUrlFromRequest()
+    {
+        $em      = $this->mockEntityManager();
+        $query   = (new Query($em))->setDQL('SELECT f FROM Foo f');
+        $adapter = PaginatorAdapter::fromRequest($query)
+            ->queryParams(['foo' => 'bar']);
+
+        $paginator = $adapter->make();
+
+        $this->assertContains('foo=bar', $paginator->url(1));
+    }
+
     /**
      * @return EntityManagerInterface|\Mockery\Mock
      */


### PR DESCRIPTION
Laravel's paginator supports attaching generated links that paginate a collection. Query parameters can be provided so that the links contain appropriate filtering parameters. The `PaginatorAdapter` does not currently support this.

### Changes proposed in this pull request:
- Add a queryParams array to PaginatorAdapter so that query parameters end up in generated pagination URLs

### Additional changes that could be implemented
- Automatically pulling query parameters from a Laravel request when using the `fromRequest` static method
- Adding the `$queryParams` parameter to the repository traits' pagination methods.