### PR TITLE
[FIX] Handle default table options in master slave connection.

### DIFF
--- a/src/Configuration/Connections/MasterSlaveConnection.php
+++ b/src/Configuration/Connections/MasterSlaveConnection.php
@@ -51,6 +51,10 @@ class MasterSlaveConnection extends Connection
             $resolvedSettings['serverVersion'] = $settings['serverVersion'];
         }
 
+        if(!empty($settings['defaultTableOptions'])) {
+            $resolvedSettings['defaultTableOptions'] = $settings['defaultTableOptions'];
+        }
+
         return $resolvedSettings;
     }
 

--- a/src/Configuration/Connections/MasterSlaveConnection.php
+++ b/src/Configuration/Connections/MasterSlaveConnection.php
@@ -51,7 +51,7 @@ class MasterSlaveConnection extends Connection
             $resolvedSettings['serverVersion'] = $settings['serverVersion'];
         }
 
-        if(!empty($settings['defaultTableOptions'])) {
+        if (!empty($settings['defaultTableOptions'])) {
             $resolvedSettings['defaultTableOptions'] = $settings['defaultTableOptions'];
         }
 

--- a/tests/Configuration/Connections/MasterSlaveConnectionTest.php
+++ b/tests/Configuration/Connections/MasterSlaveConnectionTest.php
@@ -89,7 +89,7 @@ class MasterSlaveConnectionTest extends TestCase
                     'port' => 3309
                 ],
             ],
-            'serverVersion' => '5.8',
+            'serverVersion'       => '5.8',
             'defaultTableOptions' => [
                 'charset' => 'utf8mb4',
                 'collate' => 'utf8mb4_unicode_ci',
@@ -294,7 +294,7 @@ class MasterSlaveConnectionTest extends TestCase
                 'memory'   => true,
                 'path'     => ':memory',
             ],
-            'serverVersion' => '5.8',
+            'serverVersion'       => '5.8',
             'defaultTableOptions' => [
                 'charset' => 'utf8mb4',
                 'collate' => 'utf8mb4_unicode_ci',

--- a/tests/Configuration/Connections/MasterSlaveConnectionTest.php
+++ b/tests/Configuration/Connections/MasterSlaveConnectionTest.php
@@ -90,6 +90,10 @@ class MasterSlaveConnectionTest extends TestCase
                 ],
             ],
             'serverVersion' => '5.8',
+            'defaultTableOptions' => [
+                'charset' => 'utf8mb4',
+                'collate' => 'utf8mb4_unicode_ci',
+            ]
         ];
     }
 
@@ -135,6 +139,10 @@ class MasterSlaveConnectionTest extends TestCase
                 'charset'     => 'charset',
                 'unix_socket' => 'unix_socket',
                 'prefix'      => 'prefix'
+            ],
+            'defaultTableOptions' => [
+                'charset' => 'utf8mb4',
+                'collate' => 'utf8mb4_unicode_ci',
             ],
         ];
     }
@@ -221,6 +229,11 @@ class MasterSlaveConnectionTest extends TestCase
         $expectedConfigOracle['master']['user'] = 'homestead1';
         $expectedConfigOracle['serverVersion']  = '5.8';
 
+        $expectedConfigOracle['defaultTableOptions'] = [
+            'charset' => 'utf8mb4',
+            'collate' => 'utf8mb4_unicode_ci',
+        ];
+
         return $expectedConfigOracle;
     }
 
@@ -238,6 +251,11 @@ class MasterSlaveConnectionTest extends TestCase
         $expectedConfigPgsql['slaves'][0]['sslmode'] = 'sslmode';
         $expectedConfigPgsql['slaves'][1]['sslmode'] = 'sslmode';
         $expectedConfigPgsql['serverVersion']        = '5.8';
+
+        $expectedConfigPgsql['defaultTableOptions'] = [
+            'charset' => 'utf8mb4',
+            'collate' => 'utf8mb4_unicode_ci',
+        ];
 
         return $expectedConfigPgsql;
     }
@@ -277,6 +295,10 @@ class MasterSlaveConnectionTest extends TestCase
                 'path'     => ':memory',
             ],
             'serverVersion' => '5.8',
+            'defaultTableOptions' => [
+                'charset' => 'utf8mb4',
+                'collate' => 'utf8mb4_unicode_ci',
+            ]
         ];
     }
 


### PR DESCRIPTION
Currently the doctrine `AbstractSchemaManager::createSchemaConfig` is checking the top level of the settings array to see if the `defaultTableOptions` is set. When utilizing the `MasterSlaveConnection` this setting is nested within the `master` and `slave` arrays and is getting ignored.

### Changes proposed in this pull request:
- Update the `MasterSlaveConnection::resolve()` function to check if this setting is set and add it to the top level of the returned array.
- Update the `MasterSlaveConnectionTest` to verify that the `defaultTableOptions` are being handle properly.