### PR TITLE
[FEATURE] Upgrade Php Unit Version to 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony/serializer": "^2.7|^3.0|^4.0|^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^9.3",
         "mockery/mockery": "^1.3.1",
         "barryvdh/laravel-debugbar": "~3.0",
         "itsgoingd/clockwork": "~1.9",

--- a/src/Testing/FactoryBuilder.php
+++ b/src/Testing/FactoryBuilder.php
@@ -250,6 +250,14 @@ class FactoryBuilder
     }
 
     /**
+     * @return array
+     */
+    public function getStates(): array
+    {
+        return $this->states;
+    }
+
+    /**
      * Set the states to be applied to the model.
      *
      * @param  array|mixed $states

--- a/tests/Testing/FactoryTest.php
+++ b/tests/Testing/FactoryTest.php
@@ -18,10 +18,10 @@ class FactoryTest extends MockeryTestCase
         });
 
         $builder = $factory->of('SomeClass');
-        $this->assertAttributeEquals([
-            'SomeClass' => ['withState' => function () {
-            }]
-        ], 'states', $builder);
+
+        $this->assertObjectHasAttribute('states', $builder);
+        $this->assertArrayHasKey('SomeClass', $builder->getStates());
+        $this->assertArrayHasKey('withState', $builder->getStates()['SomeClass']);
     }
 
     public function test_it_passes_along_after_creating_callback()
@@ -36,8 +36,10 @@ class FactoryTest extends MockeryTestCase
         });
 
         $builder = $factory->of('SomeClass');
-        $this->assertAttributeEquals(['SomeClass' => ['default' => [function () {
-        }]]], 'afterCreating', $builder);
+
+        $this->assertObjectHasAttribute('afterCreating', $builder);
+        $this->assertArrayHasKey('SomeClass', $builder->afterCreating);
+        $this->assertArrayHasKey('default', $builder->afterCreating['SomeClass']);
     }
 
     public function test_it_passes_along_after_making_callback()
@@ -52,8 +54,9 @@ class FactoryTest extends MockeryTestCase
         });
 
         $builder = $factory->of('SomeClass');
-        $this->assertAttributeEquals(['SomeClass' => ['default' => [function () {
-        }]]], 'afterMaking', $builder);
+        $this->assertObjectHasAttribute('afterMaking', $builder);
+        $this->assertArrayHasKey('SomeClass', $builder->afterMaking);
+        $this->assertArrayHasKey('default', $builder->afterMaking['SomeClass']);
     }
 
     public function test_it_passes_along_after_creating_state_callback()
@@ -68,8 +71,9 @@ class FactoryTest extends MockeryTestCase
         });
 
         $builder = $factory->of('SomeClass');
-        $this->assertAttributeEquals(['SomeClass' => ['withState' => [function () {
-        }]]], 'afterCreating', $builder);
+        $this->assertObjectHasAttribute('afterCreating', $builder);
+        $this->assertArrayHasKey('SomeClass', $builder->afterCreating);
+        $this->assertArrayHasKey('withState', $builder->afterCreating['SomeClass']);
     }
 
     public function test_it_passes_along_after_making_state_callback()
@@ -84,7 +88,9 @@ class FactoryTest extends MockeryTestCase
         });
 
         $builder = $factory->of('SomeClass');
-        $this->assertAttributeEquals(['SomeClass' => ['withState' => [function () {
-        }]]], 'afterMaking', $builder);
+
+        $this->assertObjectHasAttribute('afterMaking', $builder);
+        $this->assertArrayHasKey('SomeClass', $builder->afterMaking);
+        $this->assertArrayHasKey('withState', $builder->afterMaking['SomeClass']);
     }
 }


### PR DESCRIPTION
### Changes proposed in this pull request:
- Upgrade Php Unit Version to 9

"It turns out that providing functionality such as assertAttributeEquals() out-of-the-box encourages bad testing practices. This is why I decided to deprecate all assertions as well as utility methods that operate on non-public attributes in PHPUnit 8. In PHPUnit 9 they will be removed."

https://github.com/laravel-doctrine/orm/pull/457