### PR TITLE
[FIX] Update the Assert import

### DIFF
--- a/src/Testing/Concerns/InteractsWithEntities.php
+++ b/src/Testing/Concerns/InteractsWithEntities.php
@@ -3,7 +3,7 @@
 namespace LaravelDoctrine\ORM\Testing\Concerns;
 
 use Doctrine\ORM\EntityManager;
-use PHPUnit_Framework_Assert as Assert;
+use PHPUnit\Framework\Assert;
 
 trait InteractsWithEntities
 {


### PR DESCRIPTION
Fixes "Error: Class 'PHPUnit_Framework_Assert' not found"

PHPUnit introduced namespaces in v6.


### Changes proposed in this pull request:
- Update Assert import
