### PR TITLE
[FEATURE] support PrimaryReadReplicaConnection (former MasterSlaveConnection)

### DIFF
--- a/src/Configuration/Connections/PrimaryReadReplicaConnection.php
+++ b/src/Configuration/Connections/PrimaryReadReplicaConnection.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace LaravelDoctrine\ORM\Configuration\Connections;
+
+use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection as PrimaryReadReplicaDoctrineWrapper;
+use Illuminate\Contracts\Config\Repository;
+
+/**
+ * Handles primary read replica connection settings.
+ */
+class PrimaryReadReplicaConnection extends Connection
+{
+    /**
+     * @var array|Connection
+     */
+    private $resolvedBaseSettings;
+
+    /**
+     * @var array Ignored configuration fields for master slave configuration.
+     */
+    private $primaryReadReplicaConfigIgnored = ['driver'];
+
+    /**
+     * PrimaryReadReplicaConnection constructor.
+     *
+     * @param Repository       $config
+     * @param array|Connection $resolvedBaseSettings
+     */
+    public function __construct(Repository $config, $resolvedBaseSettings)
+    {
+        parent::__construct($config);
+
+        $this->resolvedBaseSettings = $resolvedBaseSettings;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve(array $settings = [])
+    {
+        $driver = $this->resolvedBaseSettings['driver'];
+
+        $resolvedSettings = [
+            'wrapperClass' => $settings['wrapperClass'] ?? PrimaryReadReplicaDoctrineWrapper::class,
+            'driver'       => $driver,
+            'primary'       => $this->getConnectionData(isset($settings['write']) ? $settings['write'] : [], $driver),
+            'replica'       => $this->getReplicasConfig($settings['read'], $driver),
+        ];
+
+        if (!empty($settings['serverVersion'])) {
+            $resolvedSettings['serverVersion'] = $settings['serverVersion'];
+        }
+
+        if (!empty($settings['defaultTableOptions'])) {
+            $resolvedSettings['defaultTableOptions'] = $settings['defaultTableOptions'];
+        }
+
+        return $resolvedSettings;
+    }
+
+    /**
+     * Returns config for read replicas connections.
+     *
+     * @param array  $replicas
+     * @param string $driver
+     *
+     * @return array
+     */
+    public function getReplicasConfig(array $replicas, $driver)
+    {
+        $handledReplicas = [];
+        foreach ($replicas as $replica) {
+            $handledReplicas[] = $this->getConnectionData($replica, $driver);
+        }
+
+        return $handledReplicas;
+    }
+
+    /**
+     * Returns single connection (replica or primary) config.
+     *
+     * @param array  $connection
+     * @param string $driver
+     *
+     * @return array
+     */
+    private function getConnectionData(array $connection, $driver)
+    {
+        $connection = $this->replaceKeyIfExists($connection, 'database', $driver === 'pdo_sqlite' ? 'path' : 'dbname');
+        $connection = $this->replaceKeyIfExists($connection, 'username', 'user');
+
+        return array_merge($this->getFilteredConfig(), $connection);
+    }
+
+    /**
+     * Returns filtered configuration to use in slaves/masters.
+     *
+     * @return array
+     */
+    private function getFilteredConfig()
+    {
+        return array_diff_key($this->resolvedBaseSettings, array_flip($this->primaryReadReplicaConfigIgnored));
+    }
+
+    /**
+     * Replaces key in array if it exists.
+     *
+     * @param array  $array
+     * @param string $oldKey
+     * @param string $newKey
+     *
+     * @return array
+     */
+    private function replaceKeyIfExists(array $array, $oldKey, $newKey)
+    {
+        if (!isset($array[$oldKey])) {
+            return $array;
+        }
+
+        $array[$newKey] = $array[$oldKey];
+        unset($array[$oldKey]);
+
+        return $array;
+    }
+}

--- a/src/Configuration/Connections/PrimaryReadReplicaConnection.php
+++ b/src/Configuration/Connections/PrimaryReadReplicaConnection.php
@@ -41,8 +41,8 @@ class PrimaryReadReplicaConnection extends Connection
         $driver = $this->resolvedBaseSettings['driver'];
 
         $resolvedSettings = [
-            'wrapperClass' => $settings['wrapperClass'] ?? PrimaryReadReplicaDoctrineWrapper::class,
-            'driver'       => $driver,
+            'wrapperClass'  => $settings['wrapperClass'] ?? PrimaryReadReplicaDoctrineWrapper::class,
+            'driver'        => $driver,
             'primary'       => $this->getConnectionData(isset($settings['write']) ? $settings['write'] : [], $driver),
             'replica'       => $this->getReplicasConfig($settings['read'], $driver),
         ];

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -4,6 +4,7 @@ namespace LaravelDoctrine\ORM;
 
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\EventManager;
+use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection as DocrinePrimaryReadReplicaConnection;
 use Doctrine\ORM\Cache\DefaultCacheFactory;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
@@ -17,6 +18,7 @@ use InvalidArgumentException;
 use LaravelDoctrine\ORM\Configuration\Cache\CacheManager;
 use LaravelDoctrine\ORM\Configuration\Connections\ConnectionManager;
 use LaravelDoctrine\ORM\Configuration\Connections\MasterSlaveConnection;
+use LaravelDoctrine\ORM\Configuration\Connections\PrimaryReadReplicaConnection;
 use LaravelDoctrine\ORM\Configuration\LaravelNamingStrategy;
 use LaravelDoctrine\ORM\Configuration\MetaData\MetaData;
 use LaravelDoctrine\ORM\Configuration\MetaData\MetaDataManager;
@@ -116,7 +118,11 @@ class EntityManagerFactory
 
         if ($this->isMasterSlaveConfigured($driver)) {
             $this->hasValidMasterSlaveConfig($driver);
-            $connection = (new MasterSlaveConnection($this->config, $connection))->resolve($driver);
+            if (class_exists(DocrinePrimaryReadReplicaConnection::class)) {
+                $connection = (new PrimaryReadReplicaConnection($this->config, $connection))->resolve($driver);
+            } else {
+                $connection = (new MasterSlaveConnection($this->config, $connection))->resolve($driver);
+            }
         }
 
         $this->setNamingStrategy($settings, $configuration);

--- a/tests/Configuration/Connections/PrimaryReadReplicaConnectionTest.php
+++ b/tests/Configuration/Connections/PrimaryReadReplicaConnectionTest.php
@@ -1,0 +1,397 @@
+<?php
+
+use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection as PrimaryReadReplicaDoctrineWrapper;
+use Illuminate\Contracts\Config\Repository;
+use LaravelDoctrine\ORM\Configuration\Connections\PrimaryReadReplicaConnection;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Basic unit tests for primary read-replica connection
+ */
+class PrimaryReadReplicaConnectionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(PrimaryReadReplicaDoctrineWrapper::class)) {
+            $this->markTestSkipped('Skipped for doctrine/dbal < 2.11');
+        }
+    }
+
+    /**
+     * Data provider for testPrimaryReplicaConnection.
+     *
+     * @return array
+     */
+    public function getPrimaryReplicaConnectionData()
+    {
+        $out = [];
+
+        // Case #0. Simple valid configuration with mysql base settings.
+        $out[] = [$this->getResolvedMysqlConfig(), $this->getInputConfig(), $this->getExpectedConfig()];
+
+        // Case #1. Configuration is only set in the read/write nodes.
+        $out[] = [['driver' => 'pdo_mysql'], $this->getNodesInputConfig(), $this->getNodesExpectedConfig()];
+
+        // Case #2. Simple valid configuration with oracle base settings.
+        $out[] = [$this->getResolvedOracleConfig(), $this->getInputConfig(), $this->getOracleExpectedConfig()];
+
+        // Case #3. Simple valid configuration with pgqsql base settings.
+        $out[] = [$this->getResolvedPgqsqlConfig(), $this->getInputConfig(), $this->getPgsqlExpectedConfig()];
+
+        // Case #4. Simple valid configuration with sqlite base settings.
+        $out[] = [$this->getResolvedSqliteConfig(), $this->getSqliteInputConfig(), $this->getSqliteExpectedConfig()];
+
+        return $out;
+    }
+
+    /**
+     * Check if primary replica connection manages configuration well.
+     *
+     * @param array $resolvedBaseSettings
+     * @param array $settings
+     * @param $expectedOutput
+     *
+     * @dataProvider getPrimaryReplicaConnectionData
+     */
+    public function testPrimaryReplicaConnection(array $resolvedBaseSettings, array $settings, array $expectedOutput)
+    {
+        $this->assertEquals(
+            $expectedOutput,
+            (new PrimaryReadReplicaConnection(m::mock(Repository::class), $resolvedBaseSettings))->resolve($settings)
+        );
+    }
+
+    /**
+     * Returns dummy input configuration for testing.
+     *
+     * @return array
+     */
+    private function getInputConfig()
+    {
+        return [
+            'driver'    => 'mysql',
+            'host'      => 'localhost',
+            'port'      => '3306',
+            'database'  => 'test',
+            'username'  => 'homestead',
+            'password'  => 'secret',
+            'charset'   => 'utf8',
+            'collation' => 'utf8_unicode_ci',
+            'prefix'    => '',
+            'strict'    => false,
+            'engine'    => null,
+            'write'     => [
+                'port'      => 3307,
+                'user'      => 'homestead1',
+                'password'  => 'secret1',
+            ],
+            'read' => [
+                [
+                    'port'     => 3308,
+                    'database' => 'test2',
+                ],
+                [
+                    'host' => 'localhost2',
+                    'port' => 3309
+                ],
+            ],
+            'serverVersion'       => '5.8',
+            'defaultTableOptions' => [
+                'charset' => 'utf8mb4',
+                'collate' => 'utf8mb4_unicode_ci',
+            ]
+        ];
+    }
+
+    /**
+     * Returns dummy expected result configuration for testing.
+     *
+     * @return array
+     */
+    private function getExpectedConfig()
+    {
+        return [
+            'wrapperClass'  => PrimaryReadReplicaDoctrineWrapper::class,
+            'driver'        => 'pdo_mysql',
+            'serverVersion' => '5.8',
+            'replica'        => [
+                [
+                    'host'        => 'localhost',
+                    'user'        => 'homestead',
+                    'password'    => 'secret',
+                    'dbname'      => 'test2',
+                    'port'        => '3308',
+                    'charset'     => 'charset',
+                    'unix_socket' => 'unix_socket',
+                    'prefix'      => 'prefix'
+                ],
+                [
+                    'host'        => 'localhost2',
+                    'user'        => 'homestead',
+                    'password'    => 'secret',
+                    'dbname'      => 'test',
+                    'port'        => '3309',
+                    'charset'     => 'charset',
+                    'unix_socket' => 'unix_socket',
+                    'prefix'      => 'prefix'
+                ]
+            ],
+            'primary' => [
+                'host'        => 'localhost',
+                'user'        => 'homestead1',
+                'password'    => 'secret1',
+                'dbname'      => 'test',
+                'port'        => '3307',
+                'charset'     => 'charset',
+                'unix_socket' => 'unix_socket',
+                'prefix'      => 'prefix'
+            ],
+            'defaultTableOptions' => [
+                'charset' => 'utf8mb4',
+                'collate' => 'utf8mb4_unicode_ci',
+            ],
+        ];
+    }
+
+    /**
+     * Returns dummy input configuration where configuration is only set in read and write nodes.
+     *
+     * @return array
+     */
+    private function getNodesInputConfig()
+    {
+        return [
+            'write' => [
+                'port'     => 3307,
+                'password' => 'secret1',
+                'host'     => 'localhost',
+                'database' => 'test',
+                'username' => 'homestead'
+            ],
+            'read' => [
+                [
+                    'port'     => 3308,
+                    'database' => 'test2',
+                    'host'     => 'localhost',
+                    'username' => 'homestead',
+                    'password' => 'secret'
+                ],
+                [
+                    'host'     => 'localhost2',
+                    'port'     => 3309,
+                    'database' => 'test',
+                    'username' => 'homestead',
+                    'password' => 'secret'
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Returns dummy expected output configuration where configuration is only set in read and write nodes.
+     *
+     * @return array
+     */
+    private function getNodesExpectedConfig()
+    {
+        return [
+            'wrapperClass' => PrimaryReadReplicaDoctrineWrapper::class,
+            'driver'       => 'pdo_mysql',
+            'replica'       => [
+                [
+                    'host'     => 'localhost',
+                    'user'     => 'homestead',
+                    'password' => 'secret',
+                    'dbname'   => 'test2',
+                    'port'     => '3308',
+                ],
+                [
+                    'host'     => 'localhost2',
+                    'user'     => 'homestead',
+                    'password' => 'secret',
+                    'dbname'   => 'test',
+                    'port'     => '3309',
+                ]
+            ],
+            'primary' => [
+                'host'     => 'localhost',
+                'user'     => 'homestead',
+                'password' => 'secret1',
+                'dbname'   => 'test',
+                'port'     => '3307',
+            ],
+        ];
+    }
+
+    /**
+     * Returns dummy expected result configuration for testing oracle connections.
+     *
+     * @return array
+     */
+    private function getOracleExpectedConfig()
+    {
+        $expectedConfigOracle                   = $this->getNodesExpectedConfig();
+        $expectedConfigOracle['driver']         = 'oci8';
+        $expectedConfigOracle['primary']['user'] = 'homestead1';
+        $expectedConfigOracle['serverVersion']  = '5.8';
+
+        $expectedConfigOracle['defaultTableOptions'] = [
+            'charset' => 'utf8mb4',
+            'collate' => 'utf8mb4_unicode_ci',
+        ];
+
+        return $expectedConfigOracle;
+    }
+
+    /**
+     * Returns dummy expected result configuration for testing pgsql connections.
+     *
+     * @return array
+     */
+    private function getPgsqlExpectedConfig()
+    {
+        $expectedConfigPgsql                         = $this->getNodesExpectedConfig();
+        $expectedConfigPgsql['driver']               = 'pgsql';
+        $expectedConfigPgsql['primary']['user']       = 'homestead1';
+        $expectedConfigPgsql['primary']['sslmode']    = 'sslmode';
+        $expectedConfigPgsql['replica'][0]['sslmode'] = 'sslmode';
+        $expectedConfigPgsql['replica'][1]['sslmode'] = 'sslmode';
+        $expectedConfigPgsql['serverVersion']        = '5.8';
+
+        $expectedConfigPgsql['defaultTableOptions'] = [
+            'charset' => 'utf8mb4',
+            'collate' => 'utf8mb4_unicode_ci',
+        ];
+
+        return $expectedConfigPgsql;
+    }
+
+    /**
+     * Returns dummy expected result configuration for testing Sqlite connections.
+     *
+     * @return array
+     */
+    private function getSqliteExpectedConfig()
+    {
+        return [
+            'wrapperClass' => PrimaryReadReplicaDoctrineWrapper::class,
+            'driver'       => 'pdo_sqlite',
+            'replica'       => [
+                [
+                    'user'     => 'homestead',
+                    'password' => 'secret',
+                    'port'     => 3308,
+                    'path'     => ':memory',
+                    'memory'   => true,
+                ],
+                [
+                    'host'     => 'localhost2',
+                    'user'     => 'homestead',
+                    'password' => 'secret',
+                    'port'     => 3309,
+                    'path'     => ':memory',
+                    'memory'   => true,
+                ]
+            ],
+            'primary' => [
+                'user'     => 'homestead1',
+                'password' => 'secret1',
+                'port'     => 3307,
+                'memory'   => true,
+                'path'     => ':memory',
+            ],
+            'serverVersion'       => '5.8',
+            'defaultTableOptions' => [
+                'charset' => 'utf8mb4',
+                'collate' => 'utf8mb4_unicode_ci',
+            ]
+        ];
+    }
+
+    /**
+     * Returns dummy input configuration for testing Sqlite connections.
+     *
+     * @return array
+     */
+    private function getSqliteInputConfig()
+    {
+        $inputConfigSqlite = $this->getInputConfig();
+        unset($inputConfigSqlite['read'][0]['database']);
+        unset($inputConfigSqlite['read'][1]['database']);
+        unset($inputConfigSqlite['write']['database']);
+
+        return $inputConfigSqlite;
+    }
+
+    /**
+     * Returns already resolved mysql configuration.
+     *
+     * @return array
+     */
+    private function getResolvedMysqlConfig()
+    {
+        return [
+            'driver'      => 'pdo_mysql',
+            'host'        => 'localhost',
+            'dbname'      => 'test',
+            'user'        => 'homestead',
+            'password'    => 'secret',
+            'charset'     => 'charset',
+            'port'        => 'port',
+            'unix_socket' => 'unix_socket',
+            'prefix'      => 'prefix'
+        ];
+    }
+
+    /**
+     * Returns already resolved oci configuration.
+     *
+     * @return array
+     */
+    private function getResolvedOracleConfig()
+    {
+        return [
+            'driver'      => 'oci8',
+            'host'        => 'localhost',
+            'dbname'      => 'test',
+            'user'        => 'homestead',
+            'password'    => 'secret',
+            'port'        => 'port',
+        ];
+    }
+
+    /**
+     * Returns already resolved sqlite configuration.
+     *
+     * @return array
+     */
+    private function getResolvedSqliteConfig()
+    {
+        return [
+            'driver'   => 'pdo_sqlite',
+            'path'     => ':memory',
+            'user'     => 'homestead',
+            'password' => 'secret',
+            'memory'   => true
+        ];
+    }
+
+    /**
+     * Returns already resolved pgsql configuration.
+     *
+     * @return array
+     */
+    private function getResolvedPgqsqlConfig()
+    {
+        return [
+            'driver'      => 'pgsql',
+            'host'        => 'localhost',
+            'dbname'      => 'test',
+            'user'        => 'homestead',
+            'password'    => 'secret',
+            'port'        => 'port',
+            'sslmode'     => 'sslmode',
+        ];
+    }
+}

--- a/tests/Configuration/Connections/PrimaryReadReplicaConnectionTest.php
+++ b/tests/Configuration/Connections/PrimaryReadReplicaConnectionTest.php
@@ -112,9 +112,9 @@ class PrimaryReadReplicaConnectionTest extends TestCase
     private function getExpectedConfig()
     {
         return [
-            'wrapperClass'  => PrimaryReadReplicaDoctrineWrapper::class,
-            'driver'        => 'pdo_mysql',
-            'serverVersion' => '5.8',
+            'wrapperClass'   => PrimaryReadReplicaDoctrineWrapper::class,
+            'driver'         => 'pdo_mysql',
+            'serverVersion'  => '5.8',
             'replica'        => [
                 [
                     'host'        => 'localhost',
@@ -196,8 +196,8 @@ class PrimaryReadReplicaConnectionTest extends TestCase
     private function getNodesExpectedConfig()
     {
         return [
-            'wrapperClass' => PrimaryReadReplicaDoctrineWrapper::class,
-            'driver'       => 'pdo_mysql',
+            'wrapperClass'  => PrimaryReadReplicaDoctrineWrapper::class,
+            'driver'        => 'pdo_mysql',
             'replica'       => [
                 [
                     'host'     => 'localhost',
@@ -231,10 +231,10 @@ class PrimaryReadReplicaConnectionTest extends TestCase
      */
     private function getOracleExpectedConfig()
     {
-        $expectedConfigOracle                   = $this->getNodesExpectedConfig();
-        $expectedConfigOracle['driver']         = 'oci8';
+        $expectedConfigOracle                    = $this->getNodesExpectedConfig();
+        $expectedConfigOracle['driver']          = 'oci8';
         $expectedConfigOracle['primary']['user'] = 'homestead1';
-        $expectedConfigOracle['serverVersion']  = '5.8';
+        $expectedConfigOracle['serverVersion']   = '5.8';
 
         $expectedConfigOracle['defaultTableOptions'] = [
             'charset' => 'utf8mb4',
@@ -251,13 +251,13 @@ class PrimaryReadReplicaConnectionTest extends TestCase
      */
     private function getPgsqlExpectedConfig()
     {
-        $expectedConfigPgsql                         = $this->getNodesExpectedConfig();
-        $expectedConfigPgsql['driver']               = 'pgsql';
+        $expectedConfigPgsql                          = $this->getNodesExpectedConfig();
+        $expectedConfigPgsql['driver']                = 'pgsql';
         $expectedConfigPgsql['primary']['user']       = 'homestead1';
         $expectedConfigPgsql['primary']['sslmode']    = 'sslmode';
         $expectedConfigPgsql['replica'][0]['sslmode'] = 'sslmode';
         $expectedConfigPgsql['replica'][1]['sslmode'] = 'sslmode';
-        $expectedConfigPgsql['serverVersion']        = '5.8';
+        $expectedConfigPgsql['serverVersion']         = '5.8';
 
         $expectedConfigPgsql['defaultTableOptions'] = [
             'charset' => 'utf8mb4',
@@ -275,8 +275,8 @@ class PrimaryReadReplicaConnectionTest extends TestCase
     private function getSqliteExpectedConfig()
     {
         return [
-            'wrapperClass' => PrimaryReadReplicaDoctrineWrapper::class,
-            'driver'       => 'pdo_sqlite',
+            'wrapperClass'  => PrimaryReadReplicaDoctrineWrapper::class,
+            'driver'        => 'pdo_sqlite',
             'replica'       => [
                 [
                     'user'     => 'homestead',

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -1210,7 +1210,7 @@ class EntityManagerFactoryTest extends TestCase
         $this->enableLaravelNamingStrategy();
 
         $this->settings['connection'] = 'mysql';
-        $entityManager = $factory->create($this->settings);
+        $entityManager                = $factory->create($this->settings);
 
         $this->assertInstanceOf(DoctrinePrimaryReadReplicaConnection::class, $entityManager->getConnection());
     }


### PR DESCRIPTION
doctrine/dbal v2.11.0 (https://github.com/doctrine/dbal/pull/4054) has deprecated MasterSlaveConnection class in favour of PrimaryReadReplicaConnection
This change adds support for this new PrimaryReadReplicaConnection class
(while being BC-compatible with MasterSlaveConnection on older dbal versions)
and would allow users to use wrapperClass that extends PrimaryPrimaryReadReplicaConnection
(which otherwise fails as this package would try to use master/slave config instead of primary/replica one)
