### PR TITLE
[FIX] Failing PHP8 tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,10 +36,10 @@
         "phpunit/phpunit": "^9.3",
         "mockery/mockery": "^1.3.1",
         "barryvdh/laravel-debugbar": "~3.0",
-        "itsgoingd/clockwork": "~1.9",
         "illuminate/log": "^8.0",
         "illuminate/notifications": "^8.0",
-        "illuminate/queue": "^8.0"
+        "illuminate/queue": "^8.0",
+        "itsgoingd/clockwork": "^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,6 +14,11 @@
             <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
+    <php>
+        <ini name="display_errors" value="On" />
+        <ini name="display_startup_errors" value="On" />
+        <ini name="error_reporting" value="E_ALL" />
+    </php>
     <filter>
         <whitelist>
             <directory suffix=".php">src/</directory>

--- a/src/DoctrineManager.php
+++ b/src/DoctrineManager.php
@@ -44,7 +44,7 @@ class DoctrineManager
      * @param string|null     $connection
      * @param string|callable $callback
      */
-    public function extend($connection = null, $callback)
+    public function extend($connection, $callback)
     {
         $this->onResolve(function (ManagerRegistry $registry) use ($connection, $callback) {
             $this->callExtendOn($connection, $callback, $registry);
@@ -68,7 +68,7 @@ class DoctrineManager
      * @param string|callable $callback
      * @param ManagerRegistry $registry
      */
-    private function callExtendOn($connection = null, $callback, ManagerRegistry $registry)
+    private function callExtendOn($connection, $callback, ManagerRegistry $registry)
     {
         $manager = $registry->getManager($connection);
 
@@ -130,7 +130,7 @@ class DoctrineManager
      * @param  ManagerRegistry $registry
      * @return MappingDriver
      */
-    public function getMetaDataDriver($connection = null, ManagerRegistry $registry)
+    public function getMetaDataDriver($connection, ManagerRegistry $registry)
     {
         $registry = $registry ?: $this->container->make('registry');
         $manager  = $registry->getManager($connection);

--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -119,13 +119,13 @@ class EntityManagerFactory
             $connection = (new MasterSlaveConnection($this->config, $connection))->resolve($driver);
         }
 
-        $this->setNamingStrategy($configuration, $settings);
+        $this->setNamingStrategy($settings, $configuration);
         $this->setCustomFunctions($configuration);
         $this->setCustomHydrationModes($configuration);
         $this->setCacheSettings($configuration);
-        $this->configureProxies($configuration, $settings);
-        $this->setCustomMappingDriverChain($configuration, $settings);
-        $this->registerPaths($configuration, $settings);
+        $this->configureProxies($settings, $configuration);
+        $this->setCustomMappingDriverChain($settings, $configuration);
+        $this->registerPaths($settings, $configuration);
         $this->setRepositoryFactory($settings, $configuration);
 
         $configuration->setDefaultRepositoryClassName(
@@ -140,13 +140,13 @@ class EntityManagerFactory
             $eventManager
         );
 
-        $manager = $this->decorateManager($manager, $settings);
+        $manager = $this->decorateManager($settings, $manager);
 
         $this->setLogger($manager, $configuration);
-        $this->registerListeners($manager, $settings);
-        $this->registerSubscribers($manager, $settings);
-        $this->registerFilters($configuration, $manager, $settings);
-        $this->registerMappingTypes($manager, $settings);
+        $this->registerListeners($settings, $manager);
+        $this->registerSubscribers($settings, $manager);
+        $this->registerFilters($settings, $configuration, $manager);
+        $this->registerMappingTypes($settings, $manager);
 
         return $manager;
     }
@@ -175,7 +175,7 @@ class EntityManagerFactory
      * @param EntityManagerInterface $manager
      * @param array                  $settings
      */
-    protected function registerListeners(EntityManagerInterface $manager, array $settings = [])
+    protected function registerListeners(array $settings, EntityManagerInterface $manager)
     {
         if (isset($settings['events']['listeners'])) {
             foreach ($settings['events']['listeners'] as $event => $listener) {
@@ -216,7 +216,7 @@ class EntityManagerFactory
      * @param EntityManagerInterface $manager
      * @param array                  $settings
      */
-    protected function registerSubscribers(EntityManagerInterface $manager, array $settings = [])
+    protected function registerSubscribers(array $settings, EntityManagerInterface $manager)
     {
         if (isset($settings['events']['subscribers'])) {
             foreach ($settings['events']['subscribers'] as $subscriber) {
@@ -237,9 +237,9 @@ class EntityManagerFactory
      * @param array                  $settings
      */
     protected function registerFilters(
+        array $settings,
         Configuration $configuration,
-        EntityManagerInterface $manager,
-        array $settings = []
+        EntityManagerInterface $manager
     ) {
         if (isset($settings['filters'])) {
             foreach ($settings['filters'] as $name => $filter) {
@@ -253,7 +253,7 @@ class EntityManagerFactory
      * @param Configuration $configuration
      * @param array         $settings
      */
-    protected function registerPaths(Configuration $configuration, array $settings = [])
+    protected function registerPaths(array $settings, Configuration $configuration)
     {
         $configuration->getMetadataDriverImpl()->addPaths(
             Arr::get($settings, 'paths', [])
@@ -277,7 +277,7 @@ class EntityManagerFactory
      * @param Configuration $configuration
      * @param array         $settings
      */
-    protected function configureProxies(Configuration $configuration, array $settings = [])
+    protected function configureProxies(array $settings, Configuration $configuration)
     {
         $configuration->setProxyDir(
             Arr::get($settings, 'proxies.path')
@@ -309,7 +309,7 @@ class EntityManagerFactory
      * @param Configuration $configuration
      * @param array         $settings
      */
-    protected function setNamingStrategy(Configuration $configuration, array $settings = [])
+    protected function setNamingStrategy(array $settings, Configuration $configuration)
     {
         $strategy = Arr::get($settings, 'naming_strategy', LaravelNamingStrategy::class);
 
@@ -394,7 +394,7 @@ class EntityManagerFactory
      * @param Configuration $configuration
      * @param array         $settings
      */
-    protected function setCustomMappingDriverChain(Configuration $configuration, array $settings = [])
+    protected function setCustomMappingDriverChain(array $settings, Configuration $configuration)
     {
         $chain = new MappingDriverChain(
             $configuration->getMetadataDriverImpl(),
@@ -421,7 +421,7 @@ class EntityManagerFactory
      *
      * @return mixed
      */
-    protected function decorateManager(EntityManagerInterface $manager, array $settings = [])
+    protected function decorateManager(array $settings, EntityManagerInterface $manager)
     {
         if ($decorator = Arr::get($settings, 'decorator', false)) {
             if (!class_exists($decorator)) {
@@ -457,7 +457,7 @@ class EntityManagerFactory
      *
      * @throws \Doctrine\DBAL\DBALException If Database Type or Doctrine Type is not found.
      */
-    protected function registerMappingTypes(EntityManagerInterface $manager, array $settings = [])
+    protected function registerMappingTypes(array $settings, EntityManagerInterface $manager)
     {
         foreach (Arr::get($settings, 'mapping_types', []) as $dbType => $doctrineType) {
             // Throw DBALException if Doctrine Type is not found.

--- a/src/Middleware/SubstituteBindings.php
+++ b/src/Middleware/SubstituteBindings.php
@@ -65,10 +65,12 @@ class SubstituteBindings
 
         foreach ($this->signatureParameters($route) as $parameter) {
             $id    = $parameters[$parameter->name];
-            $class = $parameter->getClass()->getName();
+            $class = $this->getClassName($parameter);
 
             if ($repository = $this->registry->getRepository($class)) {
-                if ($parameter->getClass()->implementsInterface(UrlRoutable::class)) {
+                $reflectionClass = new \ReflectionClass($class);
+
+                if ($reflectionClass->implementsInterface(UrlRoutable::class)) {
                     $name = call_user_func([$class, 'getRouteKeyName']);
 
                     $entity = $repository->findOneBy([
@@ -99,7 +101,18 @@ class SubstituteBindings
                 return !array_key_exists($parameter->name, $route->parameters());
             })
             ->reject(function (ReflectionParameter $parameter) {
-                return !$parameter->getClass();
+                return !$this->getClassName($parameter);
             })->toArray();
+    }
+
+    private function getClassName(ReflectionParameter $parameter): ?string
+    {
+        $class = null;
+
+        if (($type = $parameter->getType()) && $type instanceof \ReflectionNamedType) {
+            $class = $type->getName();
+        }
+
+        return $class;
     }
 }


### PR DESCRIPTION
Please prefix your pull request with one of the following: [FIX] [FEATURE].

### Changes proposed in this pull request:
- Added reporting all errors in phpunit.xml (so all warnings during tests are reported, previously it was falsely passing tests on linux but failing on macos)
- Fixed bad optional parameter in `\LaravelDoctrine\ORM\DoctrineManager::extend()`
- Fixed bad optional parameter in `\LaravelDoctrine\ORM\DoctrineManager::callExtendOn()`
- Fixed bad optional parameter in `\LaravelDoctrine\ORM\DoctrineManager:::getMetaDataDriver()`
- Updated `\LaravelDoctrine\ORM\Middleware\SubstituteBindings::substituteImplicitBindings()` to use `ReflectionParameter::getType()` and `new \ReflectionClass()` intead of deprecated `\ReflectionParameter::getClass()`
- Updated dev dependency `itsgoingd/clockwork` to `^5.0` to eliminate `Required parameter $message follows optional parameter $level` warning
- Fixed bad optional parameters in \LaravelDoctrine\ORM\EntityManagerFactory`