### PR TITLE
Added setQuoteStategy method to EntityManagerFactory

### DIFF
--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Mapping\DefaultQuoteStrategy;
 use Doctrine\ORM\Tools\Setup;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Container\Container;
@@ -120,6 +121,7 @@ class EntityManagerFactory
         }
 
         $this->setNamingStrategy($settings, $configuration);
+        $this->setQuoteStrategy($settings, $configuration);
         $this->setCustomFunctions($configuration);
         $this->setCustomHydrationModes($configuration);
         $this->setCacheSettings($configuration);
@@ -314,6 +316,19 @@ class EntityManagerFactory
         $strategy = Arr::get($settings, 'naming_strategy', LaravelNamingStrategy::class);
 
         $configuration->setNamingStrategy(
+            $this->container->make($strategy)
+        );
+    }
+
+    /**
+     * @param array         $settings
+     * @param Configuration $configuration
+     */
+    protected function setQuoteStrategy(array $settings, Configuration $configuration)
+    {
+        $strategy = Arr::get($settings, 'quote_strategy', DefaultQuoteStrategy::class);
+
+        $configuration->setQuoteStrategy(
             $this->container->make($strategy)
         );
     }


### PR DESCRIPTION
added method to EntityManagerFactory to allow to set the used
quote strategy (defaults to DefaultQuoteStrategy).
set by configuration key "quote_strategy".

Signed-off-by: smarcet <smarcet@gmail.com>

Please prefix your pull request with one of the following: [FIX] [FEATURE].

### Changes proposed in this pull request:
- Allow to set quote strategy as stated by doctrine documentation https://www.doctrine-project.org/projects/doctrine-orm-module/en/3.1.x/configuration.html#how-to-use-quote-strategy