### PR TITLE
[FIX] Missing check for builtIn type in SubstituteBindings middleware

### DIFF
--- a/src/Middleware/SubstituteBindings.php
+++ b/src/Middleware/SubstituteBindings.php
@@ -109,7 +109,7 @@ class SubstituteBindings
     {
         $class = null;
 
-        if (($type = $parameter->getType()) && $type instanceof \ReflectionNamedType) {
+        if (($type = $parameter->getType()) && $type instanceof \ReflectionNamedType && !$type->isBuiltin()) {
             $class = $type->getName();
         }
 

--- a/tests/Middleware/SubstituteBindingsTest.php
+++ b/tests/Middleware/SubstituteBindingsTest.php
@@ -167,6 +167,38 @@ class SubstituteBindingsTest extends TestCase
         $this->assertEquals(1, $router->dispatch(Request::create('foo/NAMEVALUE', 'GET'))->getContent());
     }
 
+    public function test_for_typed_value_binding()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/{value}', [
+            'middleware' => SubstituteBindings::class,
+            'uses'       => function (string $value) {
+                return $value;
+            },
+        ]);
+
+        $this->assertEquals('test', $router->dispatch(Request::create('foo/test', 'GET'))->getContent());
+
+        $router = $this->getRouter();
+        $router->get('bar/{value}', [
+            'middleware' => SubstituteBindings::class,
+            'uses'       => function (int $value) {
+                return $value;
+            },
+        ]);
+
+        $this->assertEquals(123456, $router->dispatch(Request::create('bar/123456', 'GET'))->getContent());
+
+        $router->get('doc/trine', [
+            'middleware' => SubstituteBindings::class,
+            'uses'       => function (Request $request) {
+                return $request instanceof Request ? 'request' : 'something else';
+            },
+        ]);
+
+        $this->assertEquals('request', $router->dispatch(Request::create('doc/trine', 'GET'))->getContent());
+    }
+
     protected function tearDown(): void
     {
         m::close();


### PR DESCRIPTION
For typed parameters in controllers SubstituteBindings is failing with message `Class 'type' does not exist `(where type can be string, int, etc.). To fix it was required the check of the ReflectionNamedType isBuiltin method. Added required changes and added unit test for this purpose.