### PR TITLE
[FEATURE] Add pointers to non-default connection settings

### DIFF
--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -17,6 +17,10 @@ return [
     | Available connections: mysql|oracle|pgsql|sqlite|sqlsrv
     | (Connections can be configured in the database config)
     |
+    | Depending on chosen the database connection, various other settings are
+    | available. Check the available settings for your connection type in
+    | the LaravelDoctrine\ORM\Configuration\Connections namespace.
+    |
     | --> Warning: Proxy auto generation should only be enabled in dev!
     |
     */


### PR DESCRIPTION
### Changes proposed in this pull request:
- Following up on https://github.com/laravel-doctrine/migrations/issues/112, I propose to add a hint in the config docblock, pointing users in the right direction. I tried to keep the wording concise (and of course follow Taylor's layout of 3 chars less per line, for good measure), but feel free to make suggestions.

If desired, I can add similar documentation to the laravel-doctrine/docs repo.