### PR TITLE
[FIX] Pass the Throttle config value to DoctrineTokenRepository

### DIFF
--- a/src/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Auth/Passwords/PasswordBrokerManager.php
@@ -19,7 +19,8 @@ class PasswordBrokerManager extends \Illuminate\Auth\Passwords\PasswordBrokerMan
             $this->app->make('registry')->getConnection($connection),
             $config['table'],
             $this->app['config']['app.key'],
-            $config['expire']
+            $config['expire'],
+            $config['throttle'] ?? 0
         );
     }
 }

--- a/src/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Auth/Passwords/PasswordBrokerManager.php
@@ -20,7 +20,7 @@ class PasswordBrokerManager extends \Illuminate\Auth\Passwords\PasswordBrokerMan
             $config['table'],
             $this->app['config']['app.key'],
             $config['expire'],
-            $config['throttle'] ?? 0
+            $config['throttle'] ?? 60
         );
     }
 }


### PR DESCRIPTION
Please prefix your pull request with one of the following: [FIX] [FEATURE].
[FIX]
### Changes proposed in this pull request:
- In Laravel 8, we can control the throttle value for forgot passwords in the file config/auth.php 
```
'passwords' => [
        'users' => [
            'throttle' => 30,
        ],
    ],
```
- When register the DoctrineTokenRepository using PasswordBrokerManager, currently, the throttle value is ignored.
- I applied the fix to take the throttle value if its set in config/auth.php