### PR TITLE
[IMPROVEMENT] Better IDE support for entity() helper parameters

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -4,15 +4,13 @@ if (!function_exists('entity')) {
     /**
      * Create a model factory builder for a given class, name, and amount.
      *
-     * @param  dynamic  class|class,name|class,amount|class,name,amount
+     * @param mixed ...$arguments class|class,name|class,amount|class,name,amount
      *
      * @return \LaravelDoctrine\ORM\Testing\FactoryBuilder
      */
-    function entity()
+    function entity(...$arguments)
     {
         $factory = app('LaravelDoctrine\ORM\Testing\Factory');
-
-        $arguments = func_get_args();
 
         if (isset($arguments[1]) && is_string($arguments[1])) {
             return $factory->of($arguments[0], $arguments[1])->times(isset($arguments[2]) ? $arguments[2] : 1);


### PR DESCRIPTION
Slightly refactored entity() helper method for better IDE support.
 'dynamic' keyword is not supported by PhpDoc and 'mixed is the correct one.
Also replaced `func_get_args()` with splat operator.