### PR TITLE
[FIX] EntityGenerator - Strict types error fix

### DIFF
--- a/src/Console/GenerateEntitiesCommand.php
+++ b/src/Console/GenerateEntitiesCommand.php
@@ -78,7 +78,7 @@ class GenerateEntitiesCommand extends Command
                 $entityGenerator->setGenerateStubMethods($this->option('generate-methods'));
                 $entityGenerator->setRegenerateEntityIfExists($this->option('regenerate-entities'));
                 $entityGenerator->setUpdateEntityIfExists($this->option('update-entities'));
-                $entityGenerator->setNumSpaces($this->option('num-spaces'));
+                $entityGenerator->setNumSpaces((int) $this->option('num-spaces'));
                 $entityGenerator->setBackupExisting(!$this->option('no-backup'));
 
                 if (($extend = $this->option('extend')) !== null) {


### PR DESCRIPTION
Command doctrine:generate:entities causes TypeError. EntityGenerator::setNumSpaces has int attribute with strict_types enabled.

### Changes proposed in this pull request:
- Call EntityGenerator::setNumSpaces with attribute type conversion