### PR TITLE
[FIX] Switch ArrayCacheProvider to use Illuminate\Cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "doctrine/cache": "^1",
         "doctrine/dbal": "^2.13",
         "doctrine/orm": "^2.6",
         "doctrine/persistence": "^1.3|^2.0",
         "illuminate/auth": "^6.0",
+        "illuminate/cache": "^6.0",
         "illuminate/console": "^6.0",
         "illuminate/container": "^6.0",
         "illuminate/contracts": "^6.0",

--- a/src/Configuration/Cache/ArrayCacheProvider.php
+++ b/src/Configuration/Cache/ArrayCacheProvider.php
@@ -2,18 +2,10 @@
 
 namespace LaravelDoctrine\ORM\Configuration\Cache;
 
-use Doctrine\Common\Cache\ArrayCache;
-use LaravelDoctrine\ORM\Configuration\Driver;
-
-class ArrayCacheProvider implements Driver
+class ArrayCacheProvider extends IlluminateCacheProvider
 {
     /**
-     * @param array $settings
-     *
-     * @return ArrayCache
+     * @var string
      */
-    public function resolve(array $settings = [])
-    {
-        return new ArrayCache();
-    }
+    protected $store = 'array';
 }

--- a/tests/Configuration/Cache/ArrayCacheProviderTest.php
+++ b/tests/Configuration/Cache/ArrayCacheProviderTest.php
@@ -1,17 +1,28 @@
 <?php
 
-use Doctrine\Common\Cache\ArrayCache;
+use Illuminate\Contracts\Cache\Factory;
+use Illuminate\Contracts\Cache\Repository;
 use LaravelDoctrine\ORM\Configuration\Cache\ArrayCacheProvider;
+use LaravelDoctrine\ORM\Configuration\Cache\IlluminateCacheAdapter;
+use Mockery as m;
 
 class ArrayCacheProviderTest extends AbstractCacheProviderTest
 {
     public function getProvider()
     {
-        return new ArrayCacheProvider;
+        $repo    = m::mock(Repository::class);
+        $manager = m::mock(Factory::class);
+        $manager->shouldReceive('store')
+                ->with('array')
+                ->once()->andReturn($repo);
+
+        return new ArrayCacheProvider(
+            $manager
+        );
     }
 
     public function getExpectedInstance()
     {
-        return ArrayCache::class;
+        return IlluminateCacheAdapter::class;
     }
 }

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\DBAL\Connection;
@@ -13,6 +12,7 @@ use Doctrine\ORM\Query\FilterCollection;
 use Doctrine\ORM\Repository\RepositoryFactory;
 use Doctrine\ORM\Tools\Setup;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Container\Container;
 use LaravelDoctrine\ORM\Configuration\Cache\CacheManager;
@@ -872,11 +872,15 @@ class EntityManagerFactoryTest extends TestCase
 
     protected function mockCache()
     {
+        $repository = m::mock(CacheRepository::class);
+
         $this->cache = m::mock(CacheManager::class);
 
         $this->cache->shouldReceive('driver')
                     ->times(count($this->caches) + 1) // one for each cache driver + one default
-                    ->andReturn(new ArrayCache());
+                    ->andReturn(new IlluminateCacheAdapter(
+                        $repository
+                    ));
     }
 
     protected function mockConnection()


### PR DESCRIPTION
fix #493
I know `symfony/cache` was suggested in the issue but we already use `illuminate/cache` for most fo the other drivers, so its a quick change

we should be able to up merge this to 1.6 and 1.7 branch just resolving the composer  conflicts to bump "illuminate/cache": "^6.0", version as needed