### PR TITLE
[FIX] Fixed naming issue with >1 layer of nested embeddables

### DIFF
--- a/src/Configuration/LaravelNamingStrategy.php
+++ b/src/Configuration/LaravelNamingStrategy.php
@@ -127,6 +127,6 @@ class LaravelNamingStrategy implements NamingStrategy
         $className = null,
         $embeddedClassName = null
     ) {
-        return $propertyName . '_' . $embeddedColumnName;
+        return $propertyName . '_' . $this->propertyToColumnName($embeddedColumnName);
     }
 }


### PR DESCRIPTION
### Changes proposed in this pull request:

`property_embedOne_embed_two` -> `property_embed_one_embed_two`