### PR TITLE
[Fix] Allow symfony/serializer ^5.0 to be used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "illuminate/support": "^9.0",
         "illuminate/validation": "^9.0",
         "illuminate/view": "^9.0",
-        "symfony/serializer": "^6.0",
+        "symfony/serializer": "^5.0|^6.0",
         "symfony/yaml": "^5.0|^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
### Changes proposed in this pull request:
- Add back to vendors symfony/serializer ^5.0 as a supported version
- Install symfony/yaml as was getting test failures without it?

I'm trying to upgrade our project to Laravel 9 and laravel-doctrine 1.8, but since we also use [googleads-php-lib](https://github.com/googleads/googleads-php-lib) and it does not list v6.0 as supported yet, I'm running into a dependency conflict.

I've opened an [issue](https://github.com/googleads/googleads-php-lib/issues/739) there as well, just want to get both libraries  side by side.

