### PR TITLE
[FIX] Fix normalizer error

### DIFF
--- a/src/Serializers/ArraySerializer.php
+++ b/src/Serializers/ArraySerializer.php
@@ -7,6 +7,16 @@ use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 class ArraySerializer
 {
     /**
+     * @var Serializer
+     */
+    protected $serializer;
+
+    public function __construct()
+    {
+        $this->serializer = new Serializer([$this->getNormalizer()]);
+    }
+    
+    /**
      * @param $entity
      *
      * @return array
@@ -14,7 +24,7 @@ class ArraySerializer
     public function serialize($entity)
     {
         $format = 'array';
-        $data   = $this->getNormalizer()->normalize($entity, $format);
+        $data = $this->serializer->normalize($entity, $format);
 
         return $this->getEncoder()->encode($data, $format);
     }

--- a/src/Serializers/ArraySerializer.php
+++ b/src/Serializers/ArraySerializer.php
@@ -3,6 +3,7 @@
 namespace LaravelDoctrine\ORM\Serializers;
 
 use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
+use Symfony\Component\Serializer\Serializer;
 
 class ArraySerializer
 {

--- a/tests/Serializers/ArraySerializerTest.php
+++ b/tests/Serializers/ArraySerializerTest.php
@@ -22,7 +22,8 @@ class ArraySerializerTest extends TestCase
 
         $this->assertEquals([
             'id'   => 'IDVALUE',
-            'name' => 'NAMEVALUE'
+            'name' => 'NAMEVALUE',
+            'list' => ['item1', 'item2']
         ], $array);
     }
 }
@@ -35,6 +36,8 @@ class ArrayableEntity
 
     protected $name = 'NAMEVALUE';
 
+    protected $list = ['item1', 'item2'];
+
     public function getId()
     {
         return $this->id;
@@ -43,5 +46,10 @@ class ArrayableEntity
     public function getName()
     {
         return $this->name;
+    }
+
+    public function getList()
+    {
+        return $this->list;
     }
 }


### PR DESCRIPTION
Got an error 
`
Symfony\Component\Serializer\Exception\LogicException [ 0 ]: Cannot normalize attribute "phones" because the injected serializer is not a normalizer. ~ /vendor/symfony/serializer/Normalizer/AbstractObjectNormalizer.php [ 209 ]
`
when use `\LaravelDoctrine\ORM\Serializers\Arrayable::toArray()` method on entity with json-typed property:
```
class Region 
{
    /**
     * @ORM\Column(name="phones", type="json")
     */
    protected $phones = [];
}
```

### Changes proposed in this pull request:
ArraySerializer: non-direct normalizer call.