### PR TITLE
[FIX] fix ClockworkLogger to work with custom types

### DIFF
--- a/src/Loggers/Clockwork/DoctrineDataSource.php
+++ b/src/Loggers/Clockwork/DoctrineDataSource.php
@@ -60,7 +60,7 @@ class DoctrineDataSource extends DataSource
         $queries = [];
         foreach ($this->logger->queries as $query) {
             $queries[] = [
-                'query'      => $this->formatter->format($this->connection->getDatabasePlatform(), $query['sql'], $query['params']),
+                'query'      => $this->formatter->format($this->connection->getDatabasePlatform(), $query['sql'], $query['params'], $query['types']),
                 'duration'   => $query['executionMS'] * 1000,
                 'connection' => $this->connection->getDriver()->getName()
             ];

--- a/tests/Loggers/Clockwork/DoctrineDataSourceTest.php
+++ b/tests/Loggers/Clockwork/DoctrineDataSourceTest.php
@@ -2,10 +2,14 @@
 
 use Clockwork\Request\Request;
 use Doctrine\DBAL\Logging\DebugStack;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\StringType;
+use Doctrine\DBAL\Types\Type;
 use LaravelDoctrine\ORM\Loggers\Clockwork\DoctrineDataSource;
 use Mockery as m;
 use Mockery\Mock;
 use PHPUnit\Framework\TestCase;
+use Doctrine\DBAL\Types\Types;
 
 class DoctrineDataSourceTest extends TestCase
 {
@@ -36,6 +40,7 @@ class DoctrineDataSourceTest extends TestCase
             [
                 'sql'         => 'SELECT * FROM table WHERE condition = ?',
                 'params'      => ['value'],
+                'types'       => [Types::STRING],
                 'executionMS' => 0.001
             ]
         ];
@@ -46,7 +51,7 @@ class DoctrineDataSourceTest extends TestCase
         $this->driver->shouldReceive('getName')->once()->andReturn('mysql');
 
         $this->connection->shouldReceive('getDriver')->once()->andReturn($this->driver);
-        $this->connection->shouldReceive('getDatabasePlatform')->once()->andReturn('mysql');
+        $this->connection->shouldReceive('getDatabasePlatform')->once()->andReturn(\Mockery::mock(AbstractPlatform::class));
 
         $this->source = new DoctrineDataSource($this->logger, $this->connection);
     }
@@ -62,5 +67,54 @@ class DoctrineDataSourceTest extends TestCase
                 'connection' => 'mysql'
             ]
         ], $request->databaseQueries);
+    }
+
+    public function test_transforms_a_custom_type_to_a_query(): void
+    {
+        Type::getTypeRegistry()->register('name', $this->getCustomType());
+        $this->logger->queries = [
+            [
+                'sql'         => 'SELECT * FROM table WHERE condition = ?',
+                'params'      => [$this->getValueObject()],
+                'types'       => ['name'],
+                'executionMS' => 0.001
+            ]
+        ];
+
+        $request = $this->source->resolve(new Request);
+
+        $this->assertEquals([
+            [
+                'query'      => 'SELECT * FROM table WHERE condition = "Asd"',
+                'duration'   => 1,
+                'connection' => 'mysql'
+            ]
+        ], $request->databaseQueries);
+    }
+
+    private function getValueObject(): object
+    {
+        return new class () {
+            public function getName(): string
+            {
+                return 'Asd';
+            }
+        };
+    }
+
+    private function getCustomType(): Type
+    {
+        return new class() extends StringType
+        {
+            public function getName()
+            {
+                return 'name';
+            }
+
+            public function convertToDatabaseValue($value, AbstractPlatform $platform)
+            {
+                return $value->getName();
+            }
+        };
     }
 }


### PR DESCRIPTION
Recently, I found that ClockworkLogger is not working correctly with custom types. It's caused because a lack of types passed to the formatter in src/Loggers/Clockwork/DoctrineDataSource.php.

```
Given query param is an instance of (...)ValueObject and could not be converted to a string
/vendor/laravel-doctrine/orm/src/Loggers/Formatters/ReplaceQueryParams.php:55
```

### Changes proposed in this pull request:
- pass types to the formatter in src/Loggers/Clockwork/DoctrineDataSource.php