### PR TITLE
[FEATURE] Support ODBC Driver Version 18 for SQL Server

### DIFF
--- a/src/Configuration/Connections/SqlsrvConnection.php
+++ b/src/Configuration/Connections/SqlsrvConnection.php
@@ -24,7 +24,15 @@ class SqlsrvConnection extends Connection
             'charset'             => Arr::get($settings, 'charset'),
             'defaultTableOptions' => Arr::get($settings, 'defaultTableOptions', []),
             'serverVersion'       => Arr::get($settings, 'serverVersion'),
-            'wrapperClass'        => Arr::get($settings, 'wrapperClass')
+            'wrapperClass'        => Arr::get($settings, 'wrapperClass'),
+            'driverOptions'       => array_merge([],
+                isset($settings['encrypt'])
+                    ? ['encrypt' => Arr::get($settings, 'encrypt')]
+                    : [],
+                isset($settings['trust_server_certificate'])
+                    ? ['trustServerCertificate' => Arr::get($settings, 'trust_server_certificate')]
+                    : [],
+            ),
         ];
     }
 }

--- a/tests/Configuration/Connections/SqlsrvConnectionTest.php
+++ b/tests/Configuration/Connections/SqlsrvConnectionTest.php
@@ -37,6 +37,7 @@ class SqlsrvConnectionTest extends TestCase
             'prefix'              => 'prefix',
             'charset'             => 'charset',
             'defaultTableOptions' => [],
+            'driverOptions'       => [],
         ]);
 
         $this->assertEquals('pdo_sqlsrv', $resolved['driver']);
@@ -48,6 +49,7 @@ class SqlsrvConnectionTest extends TestCase
         $this->assertEquals('prefix', $resolved['prefix']);
         $this->assertEquals('charset', $resolved['charset']);
         $this->assertCount(0, $resolved['defaultTableOptions']);
+        $this->assertCount(0, $resolved['driverOptions']);
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
### Changes proposed in this pull request:
- Add support for Microsoft's ODBC driver version 18 for SQL Server. [See breaking changes](https://learn.microsoft.com/en-us/sql/connect/odbc/windows/release-notes-odbc-sql-server-windows?view=sql-server-ver16#180)