### PR TITLE
[FEATURE] Ci update to test php 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,31 +7,21 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        php: ['8.0', '8.1']
+        php: ['8.0', '8.1', '8.2']
         doctrine: ['2.11']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          ini-values: error_reporting=E_ALL
           tools: phpunit, git
           coverage: xdebug
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - name: Cache composer dependencies
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          # Use composer.json for key, if composer.lock is not committed.
-          # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
       - name: Install dependencies for doctrine/orm ${{ matrix.doctrine }}
         run: composer require --no-progress --no-scripts --no-plugins -v -W doctrine/orm "~${{ matrix.doctrine }}.0"
       - name: PHPUnit
         run: vendor/bin/phpunit --coverage-clover=coverage.xml --coverage-text
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push, pull_request]
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  push:
+  pull_request:
 jobs:
   tests:
     name: Tests
@@ -8,7 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: ['8.0', '8.1', '8.2']
-        doctrine: ['2.11']
+        doctrine: ['2.11', '2.12', '2.13', '2.14']
     steps:
       - uses: actions/checkout@v3
       - name: Setup PHP

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ composer.phar
 composer.lock
 .DS_Store
 .php_cs.cache
+.phpunit.result.cache
 
 /tests/Stubs/storage/framework/views/*
 !/tests/Stubs/storage/framework/views/.gitkeep

--- a/src/Configuration/Connections/SqliteConnection.php
+++ b/src/Configuration/Connections/SqliteConnection.php
@@ -33,6 +33,6 @@ class SqliteConnection extends Connection
      */
     protected function isMemory(array $settings = [])
     {
-        return Str::startsWith(Arr::get($settings, 'database'), ':memory');
+        return Str::startsWith(Arr::get($settings, 'database', ''), ':memory');
     }
 }

--- a/src/Testing/Factory.php
+++ b/src/Testing/Factory.php
@@ -311,7 +311,7 @@ class Factory implements ArrayAccess
      *
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->definitions[$offset]);
     }
@@ -323,7 +323,7 @@ class Factory implements ArrayAccess
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->make($offset);
     }
@@ -336,7 +336,7 @@ class Factory implements ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         $this->define($offset, $value);
     }
@@ -348,7 +348,7 @@ class Factory implements ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->definitions[$offset]);
     }

--- a/src/Testing/FactoryBuilder.php
+++ b/src/Testing/FactoryBuilder.php
@@ -66,6 +66,20 @@ class FactoryBuilder
     protected $activeStates = [];
 
     /**
+     * The registered after making callbacks.
+     *
+     * @var array
+     */
+    public $afterMaking = [];
+
+    /**
+     * The registered after creating callbacks.
+     *
+     * @var array
+     */
+    public $afterCreating = [];
+
+    /**
      * Create an new builder instance.
      *
      * @param ManagerRegistry  $registry

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -1050,6 +1050,9 @@ class EntityManagerFactoryTest extends TestCase
         $this->configuration->shouldReceive('setDefaultRepositoryClassName')
                             ->once()
                             ->with('Repo');
+
+        $this->configuration->shouldReceive('isLazyGhostObjectEnabled')
+                            ->andReturn(false);
     }
 
     protected function enableLaravelNamingStrategy()

--- a/tests/Middleware/SubstituteBindingsTest.php
+++ b/tests/Middleware/SubstituteBindingsTest.php
@@ -6,6 +6,8 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Http\Request;
+use Illuminate\Routing\CallableDispatcher;
+use Illuminate\Routing\Contracts\CallableDispatcher as CallableDispatcherContract;
 use Illuminate\Routing\Router;
 use LaravelDoctrine\ORM\Middleware\SubstituteBindings;
 use Mockery as m;
@@ -39,6 +41,7 @@ class SubstituteBindingsTest extends TestCase
     protected function getRouter()
     {
         $container = new Container;
+        $container->bind(CallableDispatcherContract::class, fn ($app) => new CallableDispatcher($app));
         $router    = new Router(new Dispatcher, $container);
 
         $container->singleton(Registrar::class, function () use ($router) {


### PR DESCRIPTION
add 8.2 into php matrix
update used actions
ditch composer caching (not needed with composer v2)
`error_reporting=E_ALL` so can see deprecations in unit run

`SubstituteBindingsTest.php` was updated for Laravel > 9.33 re https://github.com/laravel/framework/pull/44339