### PR TITLE
[2.0] Disable autodect of cache

### DIFF
--- a/src/ORMSetupResolver.php
+++ b/src/ORMSetupResolver.php
@@ -3,7 +3,6 @@
 namespace LaravelDoctrine\ORM;
 
 use Doctrine\ORM\Configuration;
-use Doctrine\ORM\ORMSetup;
 
 class ORMSetupResolver
 {
@@ -12,9 +11,11 @@ class ORMSetupResolver
         ?string $proxyDir = null,
     ): Configuration
     {
-        return ORMSetup::createConfiguration(
-           $isDevMode,
-           $proxyDir,
-        );
+        $config = new Configuration();
+
+        $config->setProxyDir($proxyDir);
+        $config->setAutoGenerateProxyClasses($isDevMode);
+
+        return $config;
     }
 }


### PR DESCRIPTION
The new ORMSetup::createConfiguration() will automatically create cache configuration if you
do not specify cache as the third argument.
LaravelDoctrine supports setting different cache on each area, we do this in a later step.