### PR TITLE
[FIX] selectCount() does not exists. maybe: select()

### DIFF
--- a/src/Validation/DoctrinePresenceVerifier.php
+++ b/src/Validation/DoctrinePresenceVerifier.php
@@ -93,7 +93,7 @@ class DoctrinePresenceVerifier implements DatabasePresenceVerifierInterface
         $em      = $this->getEntityManager($entity);
         $builder = $em->createQueryBuilder();
 
-        $builder->selectCount('count(e)')->from($entity, 'e');
+        $builder->select('count(e)')->from($entity, 'e');
 
         return $builder;
     }

--- a/tests/Validation/DoctrinePresenceVerifierTest.php
+++ b/tests/Validation/DoctrinePresenceVerifierTest.php
@@ -212,7 +212,7 @@ class DoctrinePresenceVerifierTest extends TestCase
         $this->em->shouldReceive('createQueryBuilder')
                  ->once()->andReturn($this->builder);
 
-        $this->builder->shouldReceive('selectCount')
+        $this->builder->shouldReceive('select')
                       ->with('count(e)')->once()
                       ->andReturn($this->builder);
 
@@ -241,7 +241,7 @@ class DoctrinePresenceVerifierTest extends TestCase
         $this->em->shouldReceive('createQueryBuilder')
                  ->once()->andReturn($this->builder);
 
-        $this->builder->shouldReceive('selectCount')
+        $this->builder->shouldReceive('select')
                       ->with('count(e)')->once()
                       ->andReturn($this->builder);
 


### PR DESCRIPTION
validation rules like `exists:App\Entities\Foo,1` does not work after https://github.com/laravel-doctrine/orm/commit/57612a2aefbda6572760a4e322b424b15eb072cc

### Changes proposed in this pull request:
- use select()
