### PR TITLE
[FIX]  primaryreplica connection init

### DIFF
--- a/src/EntityManagerFactory.php
+++ b/src/EntityManagerFactory.php
@@ -524,6 +524,7 @@ class EntityManagerFactory
      * Check if slave configuration is valid.
      *
      * @param array $driverConfig
+     * @return bool
      */
     private function hasValidPrimaryReadReplicaConfig(array $driverConfig)
     {
@@ -540,5 +541,7 @@ class EntityManagerFactory
         if (($key = array_search(0, array_map('count', $slaves))) !== false) {
             throw new \InvalidArgumentException("Parameter 'read' config no. {$key} is empty.");
         }
+
+        return true;
     }
 }

--- a/tests/EntityManagerFactoryTest.php
+++ b/tests/EntityManagerFactoryTest.php
@@ -3,6 +3,7 @@
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
 use Doctrine\ORM\Cache\CacheFactory;
 use Doctrine\ORM\Cache\RegionsConfiguration;
@@ -1172,9 +1173,9 @@ class EntityManagerFactoryTest extends TestCase
         }
 
         $this->settings['connection'] = 'mysql';
-        $factory->create($this->settings);
+        $em = $factory->create($this->settings);
 
-        $this->assertTrue(true);
+        $this->assertInstanceOf(PrimaryReadReplicaConnection::class, $em->getConnection());
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
this was accidentally passing the tests
(the configuration was still accepted even though it was just empty and the EM was setup with a non primary read connection but a regular one) which I've also made a fix for to verify the resulting connection is indeed a PrimaryReadReplicaConnection


### Changes proposed in this pull request:
- fix primary read replica connection giving error upon init
