### PR TITLE
[FIX] Silence Passing null to class_exists() deprecation warning

### DIFF
--- a/src/Middleware/SubstituteBindings.php
+++ b/src/Middleware/SubstituteBindings.php
@@ -112,12 +112,11 @@ class SubstituteBindings
      */
     private function getClassName(ReflectionParameter $parameter): ?string
     {
-        $class = null;
-
         if (($type = $parameter->getType()) && $type instanceof \ReflectionNamedType && !$type->isBuiltin()) {
             $class = $type->getName();
+            return class_exists($class) ? $class : null;
         }
 
-        return class_exists($class) ? $class : null;
+        return null;
     }
 }


### PR DESCRIPTION
Since PHP 8.1 passing null to class_exists() is deprecated. I have re-factored SubstituteBindings::getClassName() to silence deprecation warning

This change could possibly be ported to other branches as well.