### PR TITLE
[FIX] Apply cache namespace from settings

### DIFF
--- a/src/Configuration/Cache/IlluminateCacheProvider.php
+++ b/src/Configuration/Cache/IlluminateCacheProvider.php
@@ -42,7 +42,7 @@ class IlluminateCacheProvider implements Driver
             trigger_error('Using driver "' . $this->store . '" with a custom store is deprecated. Please use the "illuminate" driver.', E_USER_DEPRECATED);
         }
 
-        return new Psr16Adapter($this->cache->store($store));
+        return new Psr16Adapter($this->cache->store($store), $settings['namespace'] ?? '');
     }
 
     public function getStore(): string

--- a/tests/Configuration/Cache/IlluminateCacheProviderTest.php
+++ b/tests/Configuration/Cache/IlluminateCacheProviderTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Configuration\Cache;
+
+use Illuminate\Contracts\Cache\Factory;
+use Illuminate\Contracts\Cache\Repository;
+use LaravelDoctrine\ORM\Configuration\Cache\IlluminateCacheProvider;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class IlluminateCacheProviderTest extends TestCase
+{
+    /**
+     * @var IlluminateCacheProvider
+     */
+    private $driver;
+
+    /**
+     * @var Repository|m\LegacyMockInterface|m\MockInterface
+     */
+    private $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = m::mock(Repository::class);
+        $manager = m::mock(Factory::class);
+        $manager->shouldReceive('store')
+            ->once()
+            ->andReturn($this->repository);
+
+        $this->driver = new IlluminateCacheProvider($manager);
+    }
+
+    public function test_driver_returns_provided_namespace(): void
+    {
+        $this->repository->shouldReceive('getMultiple')
+            ->withSomeOfArgs(['namespace_item'])
+            ->once();
+
+        $cache = $this->driver->resolve(['store' => 'redis', 'namespace' => 'namespace']);
+        $cache->getItem('item');
+
+        $this->assertTrue(true);
+    }
+
+    public function test_driver_has_no_namespace_by_default(): void
+    {
+        $this->repository->shouldReceive('getMultiple')
+            ->withSomeOfArgs(['item'])
+            ->once();
+
+        $cache = $this->driver->resolve(['store' => 'redis']);
+        $cache->getItem('item');
+
+        $this->assertTrue(true);
+    }
+
+    public function tearDown(): void
+    {
+        m::close();
+    }
+}


### PR DESCRIPTION
### Changes proposed in this pull request:
After upgrading to 2.0 cache namespace is not getting applied. `namespace` key in settings is ignored.
This pull request fixes this issue.
