### PR TITLE
fixed DoctrineChannel to match IlluminateRegistry::getManager()'s return type

### DIFF
--- a/src/Notifications/DoctrineChannel.php
+++ b/src/Notifications/DoctrineChannel.php
@@ -6,6 +6,7 @@ namespace LaravelDoctrine\ORM\Notifications;
 
 use Doctrine\Persistence\ManagerRegistry;
 use Illuminate\Notifications\Notification as LaravelNotification;
+use InvalidArgumentException;
 use LaravelDoctrine\ORM\Exceptions\NoEntityManagerFound;
 use RuntimeException;
 
@@ -25,9 +26,13 @@ class DoctrineChannel
         $entity = $this->getEntity($notifiable, $notification);
 
         if (method_exists($notifiable, 'routeNotificationForDoctrine')) {
-            $em = $this->registry->getManager(
-                $notifiable->routeNotificationFor('doctrine', $notification),
-            );
+            try {
+                $em = $this->registry->getManager(
+                    $notifiable->routeNotificationFor('doctrine', $notification),
+                );
+            } catch (InvalidArgumentException) {
+                $em = null;
+            }
         } else {
             $em = $this->registry->getManagerForClass($entity::class);
         }

--- a/tests/Feature/Notifications/DoctrineChannelTest.php
+++ b/tests/Feature/Notifications/DoctrineChannelTest.php
@@ -6,6 +6,7 @@ namespace LaravelDoctrineTest\ORM\Feature\Notifications;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use InvalidArgumentException;
 use LaravelDoctrine\ORM\Exceptions\NoEntityManagerFound;
 use LaravelDoctrine\ORM\Notifications\DoctrineChannel;
 use LaravelDoctrineTest\ORM\Assets\Notifications\CustomNotifiableStub;
@@ -90,7 +91,7 @@ class DoctrineChannelTest extends TestCase
 
         $this->registry->shouldReceive('getManager')
                        ->with('custom')
-                       ->andReturnNull();
+                       ->andThrow(InvalidArgumentException::class);
 
         $this->channel->send(new CustomNotifiableStub(), new NotificationStub());
     }


### PR DESCRIPTION
IlluminateRegistry::getManager() now throws exception when manager for the specified name does not exist in the registry.