### PR TITLE
Lazily resolve ManagerRegistry in EntityManagerProvider

### DIFF
--- a/src/Console/EntityManagerProvider.php
+++ b/src/Console/EntityManagerProvider.php
@@ -7,18 +7,30 @@ namespace LaravelDoctrine\ORM\Console;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Console\EntityManagerProvider as DoctrineEntityManagerProvider;
 use Doctrine\Persistence\ManagerRegistry;
+use Illuminate\Contracts\Container\Container;
 
 use function assert;
 
 class EntityManagerProvider implements DoctrineEntityManagerProvider
 {
-    public function __construct(private ManagerRegistry $managerRegistry)
+    private ManagerRegistry|null $managerRegistry = null;
+
+    public function __construct(private Container $container)
     {
+    }
+
+    private function getManagerRegistry(): ManagerRegistry
+    {
+        if ($this->managerRegistry === null) {
+            $this->managerRegistry = $this->container->make(ManagerRegistry::class);
+        }
+
+        return $this->managerRegistry;
     }
 
     public function getDefaultManager(): EntityManagerInterface
     {
-        $entityManager = $this->managerRegistry->getManager();
+        $entityManager = $this->getManagerRegistry()->getManager();
 
         assert($entityManager instanceof EntityManagerInterface);
 
@@ -27,7 +39,7 @@ class EntityManagerProvider implements DoctrineEntityManagerProvider
 
     public function getManager(string $name): EntityManagerInterface
     {
-        $entityManager = $this->managerRegistry->getManager($name);
+        $entityManager = $this->getManagerRegistry()->getManager($name);
 
         assert($entityManager instanceof EntityManagerInterface);
 

--- a/src/Console/EntityManagerProvider.php
+++ b/src/Console/EntityManagerProvider.php
@@ -13,24 +13,13 @@ use function assert;
 
 class EntityManagerProvider implements DoctrineEntityManagerProvider
 {
-    private ManagerRegistry|null $managerRegistry = null;
-
     public function __construct(private Container $container)
     {
     }
 
-    private function getManagerRegistry(): ManagerRegistry
-    {
-        if ($this->managerRegistry === null) {
-            $this->managerRegistry = $this->container->make(ManagerRegistry::class);
-        }
-
-        return $this->managerRegistry;
-    }
-
     public function getDefaultManager(): EntityManagerInterface
     {
-        $entityManager = $this->getManagerRegistry()->getManager();
+        $entityManager = $this->container->make(ManagerRegistry::class)->getManager();
 
         assert($entityManager instanceof EntityManagerInterface);
 
@@ -39,7 +28,7 @@ class EntityManagerProvider implements DoctrineEntityManagerProvider
 
     public function getManager(string $name): EntityManagerInterface
     {
-        $entityManager = $this->getManagerRegistry()->getManager($name);
+        $entityManager = $this->container->make(ManagerRegistry::class)->getManager($name);
 
         assert($entityManager instanceof EntityManagerInterface);
 


### PR DESCRIPTION
Fixes an issue where a connection will always be attempted when running any command (including package discovery) if there are custom types installed.

https://github.com/laravel-doctrine/orm/issues/663

