### PR TITLE
Use of iterator_to_array in PaginatorAdapter for incorrect limit on dataset

### DIFF
--- a/src/Pagination/PaginatorAdapter.php
+++ b/src/Pagination/PaginatorAdapter.php
@@ -11,6 +11,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 
 use function call_user_func;
+use function iterator_to_array;
 
 class PaginatorAdapter
 {
@@ -126,7 +127,7 @@ class PaginatorAdapter
         $query = $this->queryParams;
 
         return new LengthAwarePaginator(
-            $doctrinePaginator->getQuery()->getResult(),
+            iterator_to_array($doctrinePaginator),
             $doctrinePaginator->count(),
             $perPage,
             $page,


### PR DESCRIPTION
We encountered the following problem in our application after v3.0. In de pagination after the update the number per page and the count per page is not matching anymore. When a request is made with an per page of 10, the response can be incorrect when using include in the request.

For example; the response in the request with per page of 10 returns a result of 10 hamburgers. When we also want in the same request the ingredients, the include 'ingredients' is provided. Just to explain, for convenience, each hamburger has 2 related ingredients. When the same request with include is executed, the result is 5 hamburgers with each 2 ingredients. The sum of 'all items' in the response is 10, which is incorrect.

When each hamburger has 3 ingredients, the result will be 3 hamburgers with 3 ingredients, plus 1 hamburger without any ingredients. The meta data of the pagination is incorrect. When the include param is deleted from the request, the number per page and the count of items stays the same.

---

In our app, before the update, when you made a call to and endpoint with an include the number of items per page was the what you got from as response, and according to the pagination: `{{HOST}}/periods?include=closed&per_page=9`

![afbeelding](https://github.com/user-attachments/assets/fa6ab0a7-6a20-49f8-a8ad-f64099baee4f)
 
After the update the number per page and the count per page is not matching anymore.

![afbeelding](https://github.com/user-attachments/assets/cce3af0b-5345-4e06-a39e-f27535d7546c)
 
When the include param is deleted from the request, the number per page and the count of items stays the same.

---
 
Based on the last code changes, I found that the change on [this method](https://github.com/laravel-doctrine/orm/commit/1e72961306a7f49593ff1c999ad039c7e0619f11#diff-bb7b3b43c912702c063bd198c166ac44f915abcddfa04ec912bf5f69096cf1c3) broke the results. By reverting it to the use of `iterator_to_array` the number of results stays the same as the items per page.