### PR TITLE
feat: use overrides for connection settings

### DIFF
--- a/src/Configuration/Connections/MysqlConnection.php
+++ b/src/Configuration/Connections/MysqlConnection.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace LaravelDoctrine\ORM\Configuration\Connections;
 
+use function array_merge;
+
 class MysqlConnection extends Connection
 {
     /**
@@ -13,9 +15,7 @@ class MysqlConnection extends Connection
      */
     public function resolve(array $settings = []): array
     {
-        $overrides = [
-            'driver' => 'pdo_mysql',
-        ];
+        $overrides = ['driver' => 'pdo_mysql'];
 
         // Map Laravel keys to Doctrine DBAL keys
         if (isset($settings['database'])) {
@@ -34,7 +34,7 @@ class MysqlConnection extends Connection
         }
 
         // Set default for defaultTableOptions if not present
-        if (!isset($settings['defaultTableOptions'])) {
+        if (! isset($settings['defaultTableOptions'])) {
             $overrides['defaultTableOptions'] = [];
         }
 

--- a/src/Configuration/Connections/MysqlConnection.php
+++ b/src/Configuration/Connections/MysqlConnection.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace LaravelDoctrine\ORM\Configuration\Connections;
 
-use Illuminate\Support\Arr;
-
 class MysqlConnection extends Connection
 {
     /**
@@ -15,25 +13,31 @@ class MysqlConnection extends Connection
      */
     public function resolve(array $settings = []): array
     {
-        return [
-            'driver'              => 'pdo_mysql',
-            'host'                => Arr::get($settings, 'host'),
-            'dbname'              => Arr::get($settings, 'database'),
-            'user'                => Arr::get($settings, 'username'),
-            'password'            => Arr::get($settings, 'password'),
-            'charset'             => Arr::get($settings, 'charset'),
-            'port'                => Arr::get($settings, 'port'),
-            'unix_socket'         => Arr::get($settings, 'unix_socket'),
-            'ssl_key'             => Arr::get($settings, 'ssl_key'),
-            'ssl_cert'            => Arr::get($settings, 'ssl_cert'),
-            'ssl_ca'              => Arr::get($settings, 'ssl_ca'),
-            'ssl_capath'          => Arr::get($settings, 'ssl_capath'),
-            'ssl_cipher'          => Arr::get($settings, 'ssl_cipher'),
-            'prefix'              => Arr::get($settings, 'prefix'),
-            'defaultTableOptions' => Arr::get($settings, 'defaultTableOptions', []),
-            'serverVersion'       => Arr::get($settings, 'serverVersion'),
-            'wrapperClass'        => Arr::get($settings, 'wrapperClass'),
-            'driverOptions'       => Arr::get($settings, 'options', []),
+        $overrides = [
+            'driver' => 'pdo_mysql',
         ];
+
+        // Map Laravel keys to Doctrine DBAL keys
+        if (isset($settings['database'])) {
+            $overrides['dbname'] = $settings['database'];
+            unset($settings['database']);
+        }
+
+        if (isset($settings['username'])) {
+            $overrides['user'] = $settings['username'];
+            unset($settings['username']);
+        }
+
+        if (isset($settings['options'])) {
+            $overrides['driverOptions'] = $settings['options'];
+            unset($settings['options']);
+        }
+
+        // Set default for defaultTableOptions if not present
+        if (!isset($settings['defaultTableOptions'])) {
+            $overrides['defaultTableOptions'] = [];
+        }
+
+        return array_merge($settings, $overrides);
     }
 }

--- a/src/Configuration/Connections/OracleConnection.php
+++ b/src/Configuration/Connections/OracleConnection.php
@@ -15,21 +15,36 @@ class OracleConnection extends Connection
      */
     public function resolve(array $settings = []): array
     {
-        return [
-            'driver'              => 'oci8',
-            'host'                => Arr::get($settings, 'host'),
-            'dbname'              => Arr::get($settings, 'database'),
-            'servicename'         => Arr::get($settings, 'service_name'),
-            'service'             => Arr::get($settings, 'service'),
-            'user'                => Arr::get($settings, 'username'),
-            'password'            => Arr::get($settings, 'password'),
-            'charset'             => Arr::get($settings, 'charset'),
-            'port'                => Arr::get($settings, 'port'),
-            'prefix'              => Arr::get($settings, 'prefix'),
-            'defaultTableOptions' => Arr::get($settings, 'defaultTableOptions', []),
-            'persistent'          => Arr::get($settings, 'persistent'),
-            'wrapperClass'        => Arr::get($settings, 'wrapperClass'),
-            'connectstring'       => Arr::get($settings, 'connectstring'),
+        $overrides = [
+            'driver' => 'oci8',
         ];
+
+        // Map Laravel keys to Doctrine DBAL keys
+        if (isset($settings['database'])) {
+            $overrides['dbname'] = $settings['database'];
+            unset($settings['database']);
+        }
+
+        if (isset($settings['username'])) {
+            $overrides['user'] = $settings['username'];
+            unset($settings['username']);
+        }
+
+        if (isset($settings['service_name'])) {
+            $overrides['servicename'] = $settings['service_name'];
+            unset($settings['service_name']);
+        }
+
+        if (isset($settings['options'])) {
+            $overrides['driverOptions'] = $settings['options'];
+            unset($settings['options']);
+        }
+
+        // Set default for defaultTableOptions if not present
+        if (!isset($settings['defaultTableOptions'])) {
+            $overrides['defaultTableOptions'] = [];
+        }
+
+        return array_merge($settings, $overrides);
     }
 }

--- a/src/Configuration/Connections/OracleConnection.php
+++ b/src/Configuration/Connections/OracleConnection.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LaravelDoctrine\ORM\Configuration\Connections;
 
-use Illuminate\Support\Arr;
+use function array_merge;
 
 class OracleConnection extends Connection
 {
@@ -15,9 +15,7 @@ class OracleConnection extends Connection
      */
     public function resolve(array $settings = []): array
     {
-        $overrides = [
-            'driver' => 'oci8',
-        ];
+        $overrides = ['driver' => 'oci8'];
 
         // Map Laravel keys to Doctrine DBAL keys
         if (isset($settings['database'])) {
@@ -41,7 +39,7 @@ class OracleConnection extends Connection
         }
 
         // Set default for defaultTableOptions if not present
-        if (!isset($settings['defaultTableOptions'])) {
+        if (! isset($settings['defaultTableOptions'])) {
             $overrides['defaultTableOptions'] = [];
         }
 

--- a/src/Configuration/Connections/PgsqlConnection.php
+++ b/src/Configuration/Connections/PgsqlConnection.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LaravelDoctrine\ORM\Configuration\Connections;
 
-use Illuminate\Support\Arr;
+use function array_merge;
 
 class PgsqlConnection extends Connection
 {
@@ -15,9 +15,7 @@ class PgsqlConnection extends Connection
      */
     public function resolve(array $settings = []): array
     {
-         $overrides = [
-            'driver' => 'pdo_pgsql',
-        ];
+        $overrides = ['driver' => 'pdo_pgsql'];
 
         // Map Laravel keys to Doctrine DBAL keys
         if (isset($settings['database'])) {
@@ -36,7 +34,7 @@ class PgsqlConnection extends Connection
         }
 
         // Set default for defaultTableOptions if not present
-        if (!isset($settings['defaultTableOptions'])) {
+        if (! isset($settings['defaultTableOptions'])) {
             $overrides['defaultTableOptions'] = [];
         }
 

--- a/src/Configuration/Connections/PgsqlConnection.php
+++ b/src/Configuration/Connections/PgsqlConnection.php
@@ -15,25 +15,31 @@ class PgsqlConnection extends Connection
      */
     public function resolve(array $settings = []): array
     {
-        return [
-            'driver'              => 'pdo_pgsql',
-            'host'                => Arr::get($settings, 'host'),
-            'dbname'              => Arr::get($settings, 'database'),
-            'user'                => Arr::get($settings, 'username'),
-            'password'            => Arr::get($settings, 'password'),
-            'charset'             => Arr::get($settings, 'charset'),
-            'port'                => Arr::get($settings, 'port'),
-            'sslmode'             => Arr::get($settings, 'sslmode'),
-            'sslkey'              => Arr::get($settings, 'sslkey'),
-            'sslcert'             => Arr::get($settings, 'sslcert'),
-            'sslrootcert'         => Arr::get($settings, 'sslrootcert'),
-            'sslcrl'              => Arr::get($settings, 'sslcrl'),
-            'gssencmode'          => Arr::get($settings, 'gssencmode'),
-            'prefix'              => Arr::get($settings, 'prefix'),
-            'defaultTableOptions' => Arr::get($settings, 'defaultTableOptions', []),
-            'serverVersion'       => Arr::get($settings, 'serverVersion'),
-            'wrapperClass'        => Arr::get($settings, 'wrapperClass'),
-            'driverOptions'       => Arr::get($settings, 'options', []),
+         $overrides = [
+            'driver' => 'pdo_pgsql',
         ];
+
+        // Map Laravel keys to Doctrine DBAL keys
+        if (isset($settings['database'])) {
+            $overrides['dbname'] = $settings['database'];
+            unset($settings['database']);
+        }
+
+        if (isset($settings['username'])) {
+            $overrides['user'] = $settings['username'];
+            unset($settings['username']);
+        }
+
+        if (isset($settings['options'])) {
+            $overrides['driverOptions'] = $settings['options'];
+            unset($settings['options']);
+        }
+
+        // Set default for defaultTableOptions if not present
+        if (!isset($settings['defaultTableOptions'])) {
+            $overrides['defaultTableOptions'] = [];
+        }
+
+        return array_merge($settings, $overrides);
     }
 }

--- a/src/Configuration/Connections/SqliteConnection.php
+++ b/src/Configuration/Connections/SqliteConnection.php
@@ -16,17 +16,34 @@ class SqliteConnection extends Connection
      */
     public function resolve(array $settings = []): array
     {
-        return [
-            'driver'              => 'pdo_sqlite',
-            'user'                => Arr::get($settings, 'username'),
-            'password'            => Arr::get($settings, 'password'),
-            'prefix'              => Arr::get($settings, 'prefix'),
-            'memory'              => $this->isMemory($settings),
-            'path'                => Arr::get($settings, 'database'),
-            'defaultTableOptions' => Arr::get($settings, 'defaultTableOptions', []),
-            'driverOptions'       => Arr::get($settings, 'options', []),
-            'wrapperClass'        => Arr::get($settings, 'wrapperClass'),
+         $overrides = [
+            'driver' => 'pdo_sqlite',
         ];
+
+        $overrides['memory'] = $this->isMemory($settings);   
+
+        // Map Laravel keys to Doctrine DBAL keys
+        if (isset($settings['database'])) {
+            $overrides['path'] = $settings['database'];
+            unset($settings['database']);
+        }
+
+        if (isset($settings['username'])) {
+            $overrides['user'] = $settings['username'];
+            unset($settings['username']);
+        }
+        
+        if (isset($settings['options'])) {
+            $overrides['driverOptions'] = $settings['options'];
+            unset($settings['options']);
+        }
+
+        // Set default for defaultTableOptions if not present
+        if (!isset($settings['defaultTableOptions'])) {
+            $overrides['defaultTableOptions'] = [];
+        }
+
+        return array_merge($settings, $overrides);
     }
 
     /** @param mixed[] $settings */

--- a/src/Configuration/Connections/SqliteConnection.php
+++ b/src/Configuration/Connections/SqliteConnection.php
@@ -7,6 +7,8 @@ namespace LaravelDoctrine\ORM\Configuration\Connections;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
+use function array_merge;
+
 class SqliteConnection extends Connection
 {
     /**
@@ -16,11 +18,9 @@ class SqliteConnection extends Connection
      */
     public function resolve(array $settings = []): array
     {
-         $overrides = [
-            'driver' => 'pdo_sqlite',
-        ];
+        $overrides = ['driver' => 'pdo_sqlite'];
 
-        $overrides['memory'] = $this->isMemory($settings);   
+        $overrides['memory'] = $this->isMemory($settings);
 
         // Map Laravel keys to Doctrine DBAL keys
         if (isset($settings['database'])) {
@@ -32,14 +32,14 @@ class SqliteConnection extends Connection
             $overrides['user'] = $settings['username'];
             unset($settings['username']);
         }
-        
+
         if (isset($settings['options'])) {
             $overrides['driverOptions'] = $settings['options'];
             unset($settings['options']);
         }
 
         // Set default for defaultTableOptions if not present
-        if (!isset($settings['defaultTableOptions'])) {
+        if (! isset($settings['defaultTableOptions'])) {
             $overrides['defaultTableOptions'] = [];
         }
 

--- a/src/Configuration/Connections/SqlsrvConnection.php
+++ b/src/Configuration/Connections/SqlsrvConnection.php
@@ -17,29 +17,40 @@ class SqlsrvConnection extends Connection
      */
     public function resolve(array $settings = []): array
     {
-        return [
-            'driver'              => 'pdo_sqlsrv',
-            'host'                => Arr::get($settings, 'host'),
-            'dbname'              => Arr::get($settings, 'database'),
-            'user'                => Arr::get($settings, 'username'),
-            'password'            => Arr::get($settings, 'password'),
-            'port'                => Arr::get($settings, 'port'),
-            'prefix'              => Arr::get($settings, 'prefix'),
-            'charset'             => Arr::get($settings, 'charset'),
-            'defaultTableOptions' => Arr::get($settings, 'defaultTableOptions', []),
-            'serverVersion'       => Arr::get($settings, 'serverVersion'),
-            'wrapperClass'        => Arr::get($settings, 'wrapperClass'),
-            'driverOptions'       => array_merge(
-                Arr::get($settings, 'options', []),
-                // @codeCoverageIgnoreStart
-                isset($settings['encrypt'])
-                    ? ['encrypt' => Arr::get($settings, 'encrypt')]
-                    : [],
-                isset($settings['trust_server_certificate'])
-                    ? ['trustServerCertificate' => Arr::get($settings, 'trust_server_certificate')]
-                    : [],
-                // @codeCoverageIgnoreEnd
-            ),
+         $overrides = [
+            'driver' => 'pdo_sqlsrv',
         ];
+
+        // Map Laravel keys to Doctrine DBAL keys
+        if (isset($settings['database'])) {
+            $overrides['dbname'] = $settings['database'];
+            unset($settings['database']);
+        }
+
+        if (isset($settings['username'])) {
+            $overrides['user'] = $settings['username'];
+            unset($settings['username']);
+        }
+
+        $overrides['driverOptions'] = [];
+        if (isset($settings['options'])) {
+            $overrides['driverOptions'] = $settings['options'];
+            unset($settings['options']);
+        }
+
+        if (isset($settings['encrypt'])) {
+            $overrides['driverOptions']['encrypt'] = $settings['encrypt'];
+        }
+
+        if (isset($settings['trust_server_certificate'])) {
+            $overrides['driverOptions']['trustServerCertificate'] = $settings['trust_server_certificate'];
+        }
+
+        // Set default for defaultTableOptions if not present
+        if (!isset($settings['defaultTableOptions'])) {
+            $overrides['defaultTableOptions'] = [];
+        }
+
+        return array_merge($settings, $overrides);
     }
 }

--- a/src/Configuration/Connections/SqlsrvConnection.php
+++ b/src/Configuration/Connections/SqlsrvConnection.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace LaravelDoctrine\ORM\Configuration\Connections;
 
-use Illuminate\Support\Arr;
-
 use function array_merge;
 
 class SqlsrvConnection extends Connection
@@ -17,9 +15,7 @@ class SqlsrvConnection extends Connection
      */
     public function resolve(array $settings = []): array
     {
-         $overrides = [
-            'driver' => 'pdo_sqlsrv',
-        ];
+        $overrides = ['driver' => 'pdo_sqlsrv'];
 
         // Map Laravel keys to Doctrine DBAL keys
         if (isset($settings['database'])) {
@@ -47,7 +43,7 @@ class SqlsrvConnection extends Connection
         }
 
         // Set default for defaultTableOptions if not present
-        if (!isset($settings['defaultTableOptions'])) {
+        if (! isset($settings['defaultTableOptions'])) {
             $overrides['defaultTableOptions'] = [];
         }
 

--- a/tests/Feature/Configuration/Connections/OracleConnectionTest.php
+++ b/tests/Feature/Configuration/Connections/OracleConnectionTest.php
@@ -29,18 +29,20 @@ class OracleConnectionTest extends TestCase
         $resolved = $this->connection->resolve([
             'driver'              => 'oci8',
             'host'                => 'host',
+            'service_name'        => 'service_name',
             'database'            => 'database',
             'username'            => 'username',
             'password'            => 'password',
             'charset'             => 'charset',
             'port'                => 'port',
             'prefix'              => 'prefix',
-            'defaultTableOptions' => [],
+            'options'             => [],
             'persistent'          => 'persistent',
         ]);
 
         $this->assertEquals('oci8', $resolved['driver']);
         $this->assertEquals('host', $resolved['host']);
+        $this->assertEquals('service_name', $resolved['servicename']);
         $this->assertEquals('database', $resolved['dbname']);
         $this->assertEquals('username', $resolved['user']);
         $this->assertEquals('password', $resolved['password']);
@@ -48,6 +50,7 @@ class OracleConnectionTest extends TestCase
         $this->assertEquals('port', $resolved['port']);
         $this->assertEquals('prefix', $resolved['prefix']);
         $this->assertCount(0, $resolved['defaultTableOptions']);
+        $this->assertCount(0, $resolved['driverOptions']);
         $this->assertEquals('persistent', $resolved['persistent']);
     }
 

--- a/tests/Feature/Configuration/Connections/PgsqlConnectionTest.php
+++ b/tests/Feature/Configuration/Connections/PgsqlConnectionTest.php
@@ -41,8 +41,8 @@ class PgsqlConnectionTest extends TestCase
             'sslrootcert'         => 'sslrootcert',
             'sslcrl'              => 'sslcrl',
             'gssencmode'          => 'gssencmode',
-            'defaultTableOptions' => [],
-            'driverOptions'       => [],
+            'application_name'    => 'application_name',
+            'options'             => [],
         ]);
 
         $this->assertEquals('pdo_pgsql', $resolved['driver']);
@@ -59,6 +59,7 @@ class PgsqlConnectionTest extends TestCase
         $this->assertEquals('sslcrl', $resolved['sslcrl']);
         $this->assertEquals('gssencmode', $resolved['gssencmode']);
         $this->assertEquals('prefix', $resolved['prefix']);
+        $this->assertEquals('application_name', $resolved['application_name']);
         $this->assertCount(0, $resolved['defaultTableOptions']);
         $this->assertCount(0, $resolved['driverOptions']);
     }

--- a/tests/Feature/Configuration/Connections/SqliteConnectionTest.php
+++ b/tests/Feature/Configuration/Connections/SqliteConnectionTest.php
@@ -32,8 +32,7 @@ class SqliteConnectionTest extends TestCase
             'username'            => 'username',
             'password'            => 'password',
             'prefix'              => 'prefix',
-            'defaultTableOptions' => [],
-            'driverOptions'       => [],
+            'options'             => [],
         ]);
 
         $this->assertEquals('pdo_sqlite', $resolved['driver']);

--- a/tests/Feature/Configuration/Connections/SqlsrvConnectionTest.php
+++ b/tests/Feature/Configuration/Connections/SqlsrvConnectionTest.php
@@ -35,8 +35,9 @@ class SqlsrvConnectionTest extends TestCase
             'port'                => 'port',
             'prefix'              => 'prefix',
             'charset'             => 'charset',
-            'defaultTableOptions' => [],
-            'driverOptions'       => [],
+            'encrypt'             => 'encrypt',
+            'trust_server_certificate' => 'trust_server_certificate',
+            'options'             => [],
         ]);
 
         $this->assertEquals('pdo_sqlsrv', $resolved['driver']);
@@ -48,7 +49,8 @@ class SqlsrvConnectionTest extends TestCase
         $this->assertEquals('prefix', $resolved['prefix']);
         $this->assertEquals('charset', $resolved['charset']);
         $this->assertCount(0, $resolved['defaultTableOptions']);
-        $this->assertCount(0, $resolved['driverOptions']);
+        $this->assertEquals('encrypt', $resolved['driverOptions']['encrypt']);
+        $this->assertEquals('trust_server_certificate', $resolved['driverOptions']['trustServerCertificate']);
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
We recently added the `application_name` setting to our database configuration, which is supported by Laravel but was not passed into Doctrine by this package.

I'm proposing that instead of specifying the exact set of keys passed to Doctrine, the package instead overrides the required ones and passes along the remaining array as is.