### PR TITLE
Fix Static Factory Constructors

### DIFF
--- a/src/Testing/Factory.php
+++ b/src/Testing/Factory.php
@@ -66,7 +66,7 @@ class Factory implements ArrayAccess
     {
         $pathToFactories = $pathToFactories ?: database_path('factories');
 
-        return (new self($faker, $registry))->load($pathToFactories);
+        return (new static($faker, $registry))->load($pathToFactories);
     }
 
     /**

--- a/src/Testing/FactoryBuilder.php
+++ b/src/Testing/FactoryBuilder.php
@@ -162,7 +162,7 @@ class FactoryBuilder
         array $afterMaking = [],
         array $afterCreating = [],
     ): FactoryBuilder {
-        $instance         = new self($registry, $class, $name, $definitions, $faker, $afterMaking, $afterCreating);
+        $instance         = new static($registry, $class, $name, $definitions, $faker, $afterMaking, $afterCreating);
         $instance->states = $states;
 
         return $instance;


### PR DESCRIPTION
This allows classes extending the Factory and FactoryBuilder classes to call the static constructor directly without getting a return-type error.