### PR TITLE
Update IlluminateRegistry.php

### DIFF
--- a/src/IlluminateRegistry.php
+++ b/src/IlluminateRegistry.php
@@ -330,8 +330,8 @@ final class IlluminateRegistry implements ManagerRegistry
                 // @codeCoverageIgnoreEnd
             }
 
-            foreach ($entityManager->getMetadataFactory()->getAllMetadata() as $metadata) {
-                if ($metadata->getName() === $className) {
+            foreach ($entityManager->getConfiguration()->getMetadataDriverImpl()->getAllClassNames() as $_className) {
+                if ($_className === $className) {
                     return $entityManager;
                 }
             }


### PR DESCRIPTION
Previous getAllMetadata loads metadata when only classNames are needed, this solves it.

I have a project where ~500 metadata are loaded everytime \Auth is used which creates a 0.5s delay in almost every CMS api call.