### PR TITLE
fix test suite by adding expectation for native lazy objects option

### DIFF
--- a/tests/Feature/EntityManagerFactoryTest.php
+++ b/tests/Feature/EntityManagerFactoryTest.php
@@ -987,6 +987,7 @@ class EntityManagerFactoryTest extends TestCase
                             ->with('Repo');
 
         $this->configuration->shouldReceive('getMiddlewares')->once()->andReturn([]);
+        $this->configuration->shouldReceive('isNativeLazyObjectsEnabled')->andReturn(false);
 
         $schemaManagerFactory = new DefaultSchemaManagerFactory();
         $this->configuration->shouldReceive('setSchemaManagerFactory')->once();


### PR DESCRIPTION
Doctrine ORM 3.4 adding an option in the configuration for native lazy objects. That broke the test suite since the configuration is being mocked. This adds an expectation for that configuration option check to fix the test suite.