### PR TITLE
Add MariadbConnection

### DIFF
--- a/src/Configuration/Connections/MariadbConnection.php
+++ b/src/Configuration/Connections/MariadbConnection.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelDoctrine\ORM\Configuration\Connections;
+
+class MariadbConnection extends MysqlConnection
+{
+    // Only extends Mysql, as MariaDB is compatible with MySQL connection settings.
+}


### PR DESCRIPTION
Laravel 11 added `mariadb` as a valid `DB_CONNECTION` in `laravel/framework/config/database.php`.

Since MariaDB is a fork of MySQL I've simply added a new `MariadbConnection` that extends `MysqlConnection` so we can support that connection value.