### PR TITLE
Remove deprecated ReflectionProperty::setAccessible() calls

### DIFF
--- a/src/Testing/SimpleHydrator.php
+++ b/src/Testing/SimpleHydrator.php
@@ -25,7 +25,6 @@ class SimpleHydrator
     {
         if ($reflection->hasProperty($field)) {
             $property = $reflection->getProperty($field);
-            $property->setAccessible(true);
             $property->setValue($instance, $value);
         } else {
             $parent = $reflection->getParentClass();

--- a/tests/Feature/EntityManagerFactoryTest.php
+++ b/tests/Feature/EntityManagerFactoryTest.php
@@ -695,8 +695,6 @@ class EntityManagerFactoryTest extends TestCase
 
         $reflectionCache   = new ReflectionObject($metadataCache);
         $directoryProperty = $reflectionCache->getProperty('directory');
-        $directoryProperty->setAccessible(true);
-
         $this->assertStringContainsString('tests/cache', $directoryProperty->getValue($metadataCache));
         rmdir(__DIR__ . '/../cache/doctrine-cache');
     }

--- a/tests/Feature/Notifications/NotificationTest.php
+++ b/tests/Feature/Notifications/NotificationTest.php
@@ -48,7 +48,6 @@ class NotificationTest extends TestCase
 
         $reflection = new ReflectionClass($entity);
         $property   = $reflection->getProperty('id');
-        $property->setAccessible(true);
         $property->setValue($entity, 1);
 
         $entity->getId();


### PR DESCRIPTION
setAccessible() has no effect since PHP 8.1 and is deprecated in PHP 8.5.