### PR TITLE
Fix performance issue in getManagerForClass

### DIFF
--- a/src/IlluminateRegistry.php
+++ b/src/IlluminateRegistry.php
@@ -324,16 +324,8 @@ final class IlluminateRegistry implements ManagerRegistry
         }
 
         foreach ($this->getManagers() as $entityManager) {
-            if ($entityManager->getMetadataFactory()->isTransient($className)) {
-                // @codeCoverageIgnoreStart
-                continue;
-                // @codeCoverageIgnoreEnd
-            }
-
-            foreach ($entityManager->getMetadataFactory()->getAllMetadata() as $metadata) {
-                if ($metadata->getName() === $className) {
-                    return $entityManager;
-                }
+            if (!$entityManager->getMetadataFactory()->isTransient($className)) {
+                return $entityManager;
             }
         }
 

--- a/src/IlluminateRegistry.php
+++ b/src/IlluminateRegistry.php
@@ -324,7 +324,7 @@ final class IlluminateRegistry implements ManagerRegistry
         }
 
         foreach ($this->getManagers() as $entityManager) {
-            if (!$entityManager->getMetadataFactory()->isTransient($className)) {
+            if (! $entityManager->getMetadataFactory()->isTransient($className)) {
                 return $entityManager;
             }
         }

--- a/tests/Feature/IlluminateRegistryTest.php
+++ b/tests/Feature/IlluminateRegistryTest.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
-use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\ObjectManager;
 use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;

--- a/tests/Feature/IlluminateRegistryTest.php
+++ b/tests/Feature/IlluminateRegistryTest.php
@@ -430,15 +430,6 @@ class IlluminateRegistryTest extends TestCase
             ->once()
             ->andReturnFalse();
 
-        $metadata = m::mock(ClassMetadata::class);
-        $metadata->shouldReceive('getName')
-            ->once()
-            ->andReturn('LaravelDoctrineTest\ORM\Assets\Entity\Scientist');
-
-        $metadataFactory->shouldReceive('getAllMetadata')
-            ->once()
-            ->andReturn([$metadata]);
-
         $entityManager->shouldReceive('getMetadataFactory')
             ->andReturn($metadataFactory);
 
@@ -470,15 +461,6 @@ class IlluminateRegistryTest extends TestCase
             ->once()
             ->andReturnFalse();
 
-        $metadata = m::mock(ClassMetadata::class);
-        $metadata->shouldReceive('getName')
-            ->once()
-            ->andReturn('LaravelDoctrineTest\ORM\Assets\Entity\Scientist');
-
-        $metadataFactory->shouldReceive('getAllMetadata')
-            ->once()
-            ->andReturn([$metadata]);
-
         $entityManager->shouldReceive('getMetadataFactory')
             ->andReturn($metadataFactory);
 
@@ -499,16 +481,7 @@ class IlluminateRegistryTest extends TestCase
         $metadataFactory->shouldReceive('isTransient')
             ->with('LaravelDoctrineTest\ORM\Assets\Entity\Scientist')
             ->once()
-            ->andReturnFalse();
-
-        $metadata = m::mock(ClassMetadata::class);
-        $metadata->shouldReceive('getName')
-            ->once()
-            ->andReturn('LaravelDoctrineTest\ORM\Assets\Entity\Theory');
-
-        $metadataFactory->shouldReceive('getAllMetadata')
-            ->once()
-            ->andReturn([$metadata]);
+            ->andReturnTrue();
 
         $entityManager->shouldReceive('getMetadataFactory')
             ->andReturn($metadataFactory);
@@ -532,16 +505,7 @@ class IlluminateRegistryTest extends TestCase
         $metadataFactory->shouldReceive('isTransient')
             ->with('LaravelDoctrineTest\ORM\Assets\Entity\Scientist')
             ->once()
-            ->andReturnFalse();
-
-        $metadata = m::mock(ClassMetadata::class);
-        $metadata->shouldReceive('getName')
-            ->once()
-            ->andReturn('LaravelDoctrineTest\ORM\Assets\Entity\Theory');
-
-        $metadataFactory->shouldReceive('getAllMetadata')
-            ->once()
-            ->andReturn([$metadata]);
+            ->andReturnTrue();
 
         $entityManager->shouldReceive('getMetadataFactory')
             ->andReturn($metadataFactory);


### PR DESCRIPTION
Avoided using `getAllMetadata()`, since that is a heavy operation. Checking if the class is not transient is enough.

Fixes #692 